### PR TITLE
docs(readme): add multilingual README (EN / zh-CN / ja) with v2.0.0-b…

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,314 @@
+# 📜 Papyrus(パピルス)
+
+[English](README.md) · [简体中文](README.zh-CN.md) · **日本語**
+
+> ⚠️ **プレビュー版 README** — 本バージョンは今後リリース予定の **`v2.0.0-beta.3`**(TypeScript / Fastify バックエンド)を説明しています。`main` 上のコードは依然として旧 Python 版です。本ファイルはバックエンド書き換えに先行して PR で取り込まれます —— 記載の機能やインストール手順は、バックエンド書き換えが `main` にマージされた後にのみ有効です。
+
+![Version](https://img.shields.io/badge/version-v2.0.0--beta.3-blue)
+![Node.js](https://img.shields.io/badge/Node.js-24-339933)
+![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6)
+![Fastify](https://img.shields.io/badge/Fastify-5-000000)
+![React](https://img.shields.io/badge/React-19-61DAFB)
+![Electron](https://img.shields.io/badge/Electron-41-47848F)
+![License](https://img.shields.io/badge/License-MIT-yellow)
+![AI-Assisted](https://img.shields.io/badge/Dev-AI--Assisted-blueviolet)
+![Accessibility](https://img.shields.io/badge/a11y-WCAG%202.1%20AA%2FAAA-green)
+
+**Papyrus** は、高強度の記憶トレーニングに特化した、ミニマル・フルキーボード操作・AI エージェント駆動の間隔反復(SRS)復習エンジンです。
+
+> 「大道は至簡なり。」
+
+---
+
+## ✨ 主な特徴
+
+- 🚀 **フローモード** — 全操作キーボード駆動。復習中、マウスに触れる必要なし。
+- 🧠 **実証済みのスケジューリング** — SM-2 間隔反復アルゴリズムで、カードごとに次回復習間隔を自動調整。
+- 🤖 **AI エージェント** — OpenAI / Anthropic / Ollama に対応。ツール呼び出し承認フロー(手動 / 自動)と呼び出し履歴付き。
+- 📝 **ノート + Obsidian インポート** — 既存 Vault をそのまま取り込み、フォルダツリー・タグ・関係グラフで操作。
+- 🕘 **バージョン履歴とロールバック** — ノート/カードの編集ごとに内容ハッシュ付きバージョンを自動保存。ロールバックは新規バージョンを生成(履歴は破壊しない)。
+- 🔐 **API キーは暗号化保存** — AES-GCM、インストールごとに独立したマスターキー・ソルト・認証タグ。
+- 🛡️ **安全なデフォルト** — 書き込み API は auth token 必須、クラウド AI ベース URL に SSRF ガード、公開 API に rate limiting、パストラバーサルは `dev`+`ino` 包含チェックで防御。
+- ♿ **アクセシビリティ** — 全画面 WCAG 2.1 AA 準拠。AAA レベルのコントラスト、スクリーンリーダー最適化、モーション低減モードを提供。
+- 🌐 **モダンスタック** — バックエンド: Node.js + TypeScript(Fastify)、フロントエンド: React 19 + Vite + Arco Design、デスクトップシェル: Electron 41。
+- 📦 **ローカルファースト** — クラウド AI プロバイダーを指定しない限り、データはマシンから出ない。
+
+---
+
+## 📥 ダウンロード
+
+ビルド済みインストーラーは [Releases](https://github.com/PapyrusOR/Papyrus_Desktop/releases) ページに公開しています。
+
+| プラットフォーム | アーキテクチャ | 形式 |
+| :--- | :--- | :--- |
+| Windows | x64 | NSIS インストーラー(`.exe`)、ポータブル版(`.exe`) |
+| macOS | arm64 | DMG(`.dmg`)、ZIP(`.zip`) |
+| Linux | x64 | AppImage、DEB(`.deb`)、TAR.GZ |
+
+> ⚠️ `v2.0.0-beta.3` はベータ版です。データスキーマは安定していますが、UI と API は `v2.0.0` 正式版までに変更される可能性があります。
+
+---
+
+## ⌨️ キーボードショートカット(フローモード)
+
+| キー | 動作 | 効果 |
+| :--- | :--- | :--- |
+| **Space** | **答えを表示** | 巻物を広げて、巻末の内容を表示 |
+| **1** | **忘却** | 不慣れとしてマーク。短期間で再出題 |
+| **2** | **曖昧** | 不確かとしてマーク。後ほど再復習 |
+| **3** | **瞬殺** | 記憶が確立。復習間隔を線形に倍増 |
+| **Tab** | **ナビゲーション** | 操作可能要素間でフォーカス切替 |
+| **Ctrl + K** | **検索** | グローバル検索を開く |
+
+---
+
+## 🚀 クイックスタート(ソースから実行)
+
+### 必要環境
+
+- **Node.js** 24 以上
+- **npm** 11 以上
+
+### 依存関係のインストール
+
+```bash
+# postinstall が frontend/ と backend/ にカスケード
+npm install
+```
+
+### 開発モードで起動
+
+```bash
+# backend(Fastify, tsx watch)+ frontend(Vite)を並行起動
+npm run dev
+
+# Electron シェルも一緒に起動する場合
+npm run electron:dev
+```
+
+- フロントエンド: <http://localhost:5173>
+- バックエンド API: <http://127.0.0.1:8000>
+- ヘルスチェック: <http://127.0.0.1:8000/api/health>
+
+### インストーラーのビルド
+
+```bash
+npm run electron:build          # 現在のプラットフォーム
+npm run electron:build:win      # Windows のみ
+npm run electron:build:mac      # macOS のみ
+npm run electron:build:linux    # Linux のみ
+```
+
+成果物は `dist-electron/` に出力されます。
+
+---
+
+## 📥 カードの一括インポート
+
+UTF-8 エンコードの `.txt` ファイルを以下の形式で用意します:
+
+```text
+問題またはシナリオ A === トリガーまたは答え A
+
+問題またはシナリオ B === トリガーまたは答え B
+```
+
+> 各カードは `===` で区切ります。グループ間に空行を入れると見やすくなります。
+
+---
+
+## 🤖 AI 設定
+
+### 1. プロバイダーの設定
+
+サイドバーの **⚙️ 設定** から API キーを追加:
+
+- **OpenAI** — <https://platform.openai.com/api-keys> でキーを取得
+- **Anthropic** — <https://console.anthropic.com/> でキーを取得
+- **Ollama** — ローカル実行。API キー不要
+  ```bash
+  # インストール: https://ollama.ai
+  ollama pull llama2
+  ```
+
+API キーは **暗号化して保存**(AES-GCM、インストールごとのマスターキー)されます。
+
+### 2. モードの選択
+
+- **エージェントモード** — モデルがツール呼び出し承認フローの下でツール(カードの追加 / 編集 / 削除、ノート検索など)を使用可能。
+- **チャットモード** — 純粋な会話。副作用なし。
+
+### 3. パラメータ調整
+
+- **Temperature** — 0~2、高いほどランダム。
+- **Max Tokens** — 1 回の応答長の上限。
+- **ツール承認** — `manual`(キューでレビュー)または `auto`(許可リスト駆動)。
+
+---
+
+## ♿ アクセシビリティ
+
+Papyrus はすべての方が使えるよう設計しています:
+
+- **キーボードナビゲーション** — 全ページで Tab による完全なトラバーサル。
+- **スクリーンリーダー** — セマンティックな ARIA ラベル、状態変化を伝える live region。
+- **コントラスト** — **設定 → アクセシビリティ** で AAA レベルのカラーパレットを利用可能。
+- **モーション** — OS の設定に追従する「モーション低減」モード。
+
+---
+
+## 🛠️ アーキテクチャ
+
+```
+Papyrus/
+├── backend/                  # Node.js + TypeScript(Fastify)
+│   └── src/
+│       ├── api/              # Fastify ルートとサーバーエントリ(server.ts)
+│       ├── core/             # カード、ノート、SM-2、バージョン管理、暗号化
+│       ├── db/               # JSON 永続化とマイグレーション
+│       ├── ai/               # プロバイダー抽象化、ツールマネージャー、LLM キャッシュ
+│       ├── mcp/              # MCP REST エンドポイント(ノート / Vault CRUD)
+│       ├── integrations/     # Obsidian インポート、ファイル監視(chokidar)
+│       └── utils/            # 共通ユーティリティ
+├── frontend/                 # React 19 + TypeScript(Vite)
+│   └── src/
+│       ├── StartPage/        # ホーム(最近のノート、復習キュー、二十四節気テーマ)
+│       ├── ScrollPage/       # フラッシュカード学習(「巻物」)
+│       ├── NotesPage/        # ノート管理とグラフビュー
+│       ├── SettingsPage/     # 設定、AI、アクセシビリティ
+│       └── ChartsPage/       # 統計と進捗グラフ
+├── electron/                 # メインプロセス + preload(Electron 41)
+├── scripts/                  # build-electron.js、extract-changelog.js
+├── e2e/                      # Playwright E2E テスト
+└── docs/                     # プロジェクトドキュメント
+```
+
+### スタック
+
+- **バックエンド** — Node.js 24、TypeScript 5、Fastify 5、Jest
+- **フロントエンド** — React 19、TypeScript 5、Vite、Arco Design、Tailwind CSS
+- **デスクトップ** — Electron 41 + electron-builder
+- **アルゴリズム** — SM-2 間隔反復
+- **ストレージ** — ローカル JSON ファイル、内容ハッシュ付きバージョン
+- **CI/CD** — GitHub Actions マトリックス(Windows x64、macOS arm64、Linux x64)
+
+---
+
+## 🔧 開発
+
+### バックエンド
+
+```bash
+cd backend
+npm run dev         # tsx watch で Fastify をホットリロード
+npm run build       # TypeScript を dist/ にコンパイル
+npm run typecheck   # tsc --noEmit
+npm test            # Jest ユニット + 統合テスト
+npm start           # コンパイル後の dist/api/server.js を実行
+```
+
+バックエンドはデフォルトで `127.0.0.1:8000` を listen します。`PAPYRUS_PORT` で上書き可能。
+
+### フロントエンド
+
+```bash
+cd frontend
+npm run dev         # Vite 開発サーバー(http://localhost:5173)
+npm run build       # 本番ビルドを dist/ へ
+npm run typecheck   # TypeScript 型チェック
+```
+
+### リリースフロー
+
+```bash
+# 1. CHANGELOG.md の [Unreleased] を新しいバージョン番号下にアーカイブ
+
+# 2. (任意)GitHub Release に載るセクションをプレビュー
+node scripts/extract-changelog.js v2.0.0
+
+# 3. コミット
+git add CHANGELOG.md
+git commit -m "chore: release v2.0.0"
+
+# 4. タグ付けして push — GitHub Actions が 3 プラットフォームをビルドし、
+#    対応する CHANGELOG セクションを抽出してインストーラーをアップロード。
+git tag v2.0.0
+git push origin main --tags
+```
+
+---
+
+## 📁 データファイル
+
+デフォルトでは、ユーザーデータは `paths.dataDir`(初期値 `$HOME/PapyrusData`、`PAPYRUS_DATA_DIR` で上書き可)以下に保存されます:
+
+- `ai_config.json` — プロバイダー、モデル、暗号化された API キー
+- `Papyrusdata.json` — カードと SM-2 の復習状態
+- `notes.json` — ノート
+- `~/.papyrus/auth.token` — 書き込み API に必要な token(初回起動時に自動生成)
+
+---
+
+## ⚠️ 注意事項
+
+1. **API 料金** — OpenAI と Anthropic は使用量課金。プロバイダー側で予算を設定することを推奨。
+2. **ローカルモデル** — Ollama は無料ですが、それなりのハードウェアが必要。
+3. **ネットワーク** — クラウドプロバイダーは安定した接続が必要。
+4. **プライバシー** — ローカルモデルはローカル完結。クラウドプロバイダーには送信内容が見えます。
+5. **同時実行** — JSON ファイルストレージは単一書き込み前提。同じデータディレクトリで複数インスタンスを動かさないでください。
+
+---
+
+## 📚 ドキュメント
+
+### ユーザーガイド
+- [クイックスタート](docs/guides/QUICKSTART.md) — 5 分で開始
+- [アクセシビリティ設定](docs/guides/A11Y_SETTINGS.md)
+- [バージョン情報](docs/guides/VERSION.md)
+- [変更履歴](CHANGELOG.md) — GitHub Release に自動連携
+
+### 開発者ガイド
+- [プロジェクト構造](docs/PROJECT_STRUCTURE.md)
+- [環境要件](docs/guides/ENVIRONMENT_REQUIREMENTS.md)
+- [アクセシビリティ開発ガイド](docs/guides/ACCESSIBILITY_GUIDE.md)
+- [UI デザイントークン](docs/guides/UI_TOKENS.md)
+- [REST API リファレンス](docs/API.md)
+- [拡張機能の開発](docs/EXTENSIONS.md) と [拡張機能テンプレート](examples/extension-template/)
+- [Electron パッケージング](ELECTRON.md)
+- [開発環境](README-DEV.md)
+
+### AI 機能
+- [AI 概要](docs/AI_README.md)
+- [AI ツールデモ](docs/AI_TOOLS_DEMO.md)
+- [ツール呼び出し承認の設計](docs/tool_call_approval.md)
+
+---
+
+## 💡 作者の言葉
+
+正直に言うと、この作品の誕生はそんなに理想的でも壮大でもありません。
+
+なぜ作ったかって?ある日、AI 学習をやっていて、知識ポイントを暗記するために Anki をダウンロードしたんです。インストールしたら、アップデートをチェックしたいと言う。アップデートはサーバーに繋ぎたい。そしてどうしても繋がらない。
+
+ふと隣を見ると Gemini がいる。じゃあ書いてもらおう、と。書いては直し、直しては書き、そのまま使い始めた。
+
+公開するつもりは元々なかったんです。じゃあなぜ出したかって?
+
+昨日、ずっと放置していたアカウントで彼女のリポジトリに star を付けようとしたら、GitHub にボット判定されてアクティビティを全部消されました。腹が立った。AI を「使っている」だけで、自分自身が AI じゃない。AI じゃないことを証明するために、ちょうど手元にあったこいつを少し直して、ここに上げたわけです。
+
+小話はおしまい。今日はもう旧暦正月 6 日。じきに夜が明ける。苦学生、ため息をついて愚痴をこぼすしかない、そんな夜です。
+
+好きな言葉があります:**Veritas vos liberabit**(知識は人を自由にする)。皆さんと共に。これは私の初めてのオープンソースプロジェクトです。どうかお手柔らかに。
+
+これを遅ればせながらの新年の挨拶ということで。
+**新しい年、知識という刃を手に、夜の闇を切り裂き、まっすぐ夜明けへ向かわんことを。**
+
+---
+
+## 📄 ライセンス
+
+[MIT](LICENSE)
+
+---
+
+**Papyrus** — 学びをよりスマートに、記憶をより科学的に。

--- a/README.md
+++ b/README.md
@@ -1,161 +1,314 @@
-# 📜 Papyrus (莎草纸)
+# 📜 Papyrus
 
-![Minecraft Paper](https://img.shields.io/badge/Icon-Minecraft_Paper-green)
-![Python](https://img.shields.io/badge/Python-3.8-blue)
+**English** · [简体中文](README.zh-CN.md) · [日本語](README.ja.md)
+
+> ⚠️ **Preview README** — this version describes the upcoming **`v2.0.0-beta.3`** (TypeScript / Fastify backend). The code currently on `main` is still the legacy Python build. This README ships ahead of the backend rewrite via PR — feature mentions and install instructions will only apply once the backend rewrite lands on `main`.
+
+![Version](https://img.shields.io/badge/version-v2.0.0--beta.3-blue)
+![Node.js](https://img.shields.io/badge/Node.js-24-339933)
+![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6)
+![Fastify](https://img.shields.io/badge/Fastify-5-000000)
+![React](https://img.shields.io/badge/React-19-61DAFB)
+![Electron](https://img.shields.io/badge/Electron-41-47848F)
 ![License](https://img.shields.io/badge/License-MIT-yellow)
 ![AI-Assisted](https://img.shields.io/badge/Dev-AI--Assisted-blueviolet)
+![Accessibility](https://img.shields.io/badge/a11y-WCAG%202.1%20AA%2FAAA-green)
 
-**Papyrus** 是一款专注于高强度模型记忆的极简、高效、全键盘驱动的AI Agent驱动暗记（SRS）复习引擎。
+**Papyrus** is a minimalist, keyboard-driven, AI-agent-powered spaced-repetition (SRS) review engine, designed for high-intensity memory drilling.
 
-> “大道至简。”
-
----
-
-## ✨ 核心特性
-
-- 🚀 **极简交互**：全流程键盘驱动，无需触碰鼠标，助你进入深度复习的“心流”状态。
-- 🧠 **智能调度**：内置基于艾宾浩斯遗忘曲线逻辑的简化间隔复习算法，根据掌握程度自动安排下一次复习时间。
-- 📦 **轻量便携**：单文件 `.exe` 运行，零依赖，数据本地化存储于 `Papyrusdata.json`，隐私安全。
+> *"Simplicity is the ultimate sophistication."*
 
 ---
 
-## ⌨️ 快捷键 (心流模式)
+## ✨ Highlights
 
-| 按键 | 动作 | 效果 |
+- 🚀 **Flow-state interaction** — fully keyboard-driven; never touch the mouse during a review session.
+- 🧠 **Proven scheduling** — built-in SM-2 spaced-repetition algorithm tunes the next review interval per card.
+- 🤖 **AI agent** — OpenAI / Anthropic / Ollama, with tool-call approval flow (manual or auto-approve) and call history.
+- 📝 **Notes + Obsidian import** — bring your existing vault, navigate via folder tree, tags, and a relation graph.
+- 🕘 **Version history & rollback** — every note/card edit auto-saves a content-hashed version; rollback creates a forward version (no destructive history).
+- 🔐 **Encrypted API keys at rest** — AES-GCM with a per-install master key, salt, and auth tag.
+- 🛡️ **Hardened defaults** — auth token required for write APIs, SSRF guard for AI base URLs, rate limiting on the public surface, path-traversal protection (`dev`+`ino` containment).
+- ♿ **Accessibility** — WCAG 2.1 AA across the app, with AAA-grade contrast options, screen-reader optimization, and reduced-motion modes.
+- 🌐 **Modern stack** — Node.js + TypeScript (Fastify) backend, React 19 + Vite + Arco Design frontend, Electron 41 shell.
+- 📦 **Local-first** — your data never leaves the machine unless you point an AI provider at the cloud.
+
+---
+
+## 📥 Download
+
+Pre-built installers are published on the [Releases](https://github.com/PapyrusOR/Papyrus_Desktop/releases) page.
+
+| Platform | Architecture | Formats |
 | :--- | :--- | :--- |
-| **Space (空格)** | **揭晓答案** | 展开卷轴，查看“卷尾”内容 |
-| **1** | **忘记** | 标记为不熟悉，短期内高频重现 |
-| **2** | **模糊** | 标记为不确定，稍后再次复习 |
-| **3** | **秒杀** | 记忆极其稳固，复习间隔线性翻倍 |
+| Windows | x64 | NSIS installer (`.exe`), Portable (`.exe`) |
+| macOS | arm64 | DMG (`.dmg`), ZIP (`.zip`) |
+| Linux | x64 | AppImage, DEB (`.deb`), TAR.GZ |
+
+> ⚠️ `v2.0.0-beta.3` is a beta. The data schema is stable, but the UI and APIs may still evolve before `v2.0.0`.
 
 ---
 
-## 📥 批量导入格式
+## ⌨️ Keyboard Shortcuts (Flow Mode)
 
-准备一个 `UTF-8` 编码的 `.txt` 文件，格式如下：
+| Key | Action | Effect |
+| :--- | :--- | :--- |
+| **Space** | Reveal answer | Unrolls the scroll, showing the answer side |
+| **1** | Forgot | Mark unfamiliar; the card returns soon |
+| **2** | Hazy | Mark uncertain; the card returns later today |
+| **3** | Aced | Memory rock-solid; interval doubles linearly |
+| **Tab** | Navigate | Move focus between interactive elements |
+| **Ctrl + K** | Search | Open the global search palette |
 
-```text
-模型场景或问题 A === 核心扳机或答案 A
+---
 
-模型场景或问题 B === 核心扳机或答案 B
+## 🚀 Quick Start (from source)
+
+### Prerequisites
+
+- **Node.js** 24+
+- **npm** 11+
+
+### Install
+
+```bash
+# postinstall cascades into frontend/ and backend/
+npm install
 ```
 
-*提示：每组卡片通过 `===` 分隔，组与组之间建议空一行以保持清晰。*
+### Run in dev mode
+
+```bash
+# Concurrently runs backend (Fastify, tsx watch) + frontend (Vite)
+npm run dev
+
+# Or, with the Electron shell on top
+npm run electron:dev
+```
+
+- Frontend: <http://localhost:5173>
+- Backend API: <http://127.0.0.1:8000>
+- Health check: <http://127.0.0.1:8000/api/health>
+
+### Build installers
+
+```bash
+npm run electron:build          # current platform
+npm run electron:build:win      # Windows only
+npm run electron:build:mac      # macOS only
+npm run electron:build:linux    # Linux only
+```
+
+Installers are emitted to `dist-electron/`.
 
 ---
 
-## 🚀 下载与使用 (Download & Usage)
+## 📥 Bulk Card Import
 
-### 1. 获取程序
-前往 [Releases](https://github.com/Alpaca233114514/Papyrus/releases) 页面，下载最新版本。
+Prepare a UTF-8 `.txt` file in this format:
 
-### 2. 运行说明
-1. 解压下载的 `.zip` 文件到任意文件夹。
-3. 双击 `Papyrus.exe` 即可启动。
-> **注意：** 请勿将 `.exe` 单独移动到其他地方运行，否则程序将无法加载图标或读取之前的复习进度（仅限v1.0.0版本）。
+```text
+Question or scenario A === Trigger or answer A
 
-### 3.AI功能使用
-### 1. 配置 API
+Question or scenario B === Trigger or answer B
+```
 
-点击侧边栏的 "⚙️ 设置" 按钮，输入你的 API Key：
+> Cards within a group are separated by `===`. Leave a blank line between groups for readability.
 
-- **OpenAI**: 在 https://platform.openai.com/api-keys 获取
-- **Anthropic**: 在 https://console.anthropic.com/ 获取
-- **Ollama**: 本地运行，无需API Key
+---
+
+## 🤖 AI Configuration
+
+### 1. Configure a provider
+
+Open the in-app **⚙️ Settings** sidebar and add an API key:
+
+- **OpenAI** — get a key at <https://platform.openai.com/api-keys>
+- **Anthropic** — get a key at <https://console.anthropic.com/>
+- **Ollama** — runs locally, no API key needed
   ```bash
-  # 安装 Ollama
-  # 下载: https://ollama.ai
-  
-  # 拉取模型
+  # Install: https://ollama.ai
   ollama pull llama2
   ```
 
-### 2. 模式配置
-#### Agent模式
-AI将使用工具调用进行卡片的添加，编辑，删除等操作
-#### Chat模式
-仅保留聊天功能
+API keys are persisted **encrypted at rest** (AES-GCM with a per-install master key).
 
-### 3. 参数调整
+### 2. Pick a mode
 
-在设置中可以调整：
-- **Temperature**: 控制创造性（0-2，越高越随机）
-- **Max Tokens**: 最大回复长度
+- **Agent mode** — the model can invoke tools (add / edit / delete cards, search notes, …) under a tool-call approval flow.
+- **Chat mode** — pure conversation, no side effects.
 
-## 配置文件
+### 3. Tune
 
-AI配置保存在 `data/ai_config.json`，包含：
-- API密钥
-- 模型选择
-- 参数设置
-
-## 注意事项
-
-1. **API费用**: OpenAI和Anthropic按使用量收费，建议设置预算
-2. **本地模型**: Ollama完全免费，但需要较好的硬件
-3. **网络**: 云端API需要稳定的网络连接
-4. **隐私**: 本地模型数据不会上传，云端API会发送问题内容
-
-## 故障排除
-
-### AI功能不可用
-- 检查是否安装了 `requests` 库
-- 查看控制台错误信息
-
-### API调用失败
-- 检查API Key是否正确
-- 检查网络连接
-- 确认API额度是否充足
-
-### Ollama连接失败
-- 确认Ollama服务是否运行
-- 检查端口是否为 11434
-- 尝试: `ollama serve`
+- **Temperature** — 0 to 2, higher is more random.
+- **Max tokens** — cap on response length.
+- **Tool approval** — `manual` (queue and review) or `auto` (allow-list driven).
 
 ---
 
-## 🛠️ 技术细节 (For Developers)
+## ♿ Accessibility
 
-- **开发模式**: 本人为主，AI辅助(Cluade Sonnet 4.6,Gemini 3.0 Pro)
-- **语言**: Python 3.8 (Tkinter)
-- **工程化**: 采用 `PyInstaller` 封装，处理了 `sys._MEIPASS` 资源路径兼容性。
-- **开源协议**: MIT License
-- **鸣谢**: 图标素材来源于 Minecraft Wiki (Mojang Studio)。
+Papyrus aims to be usable by everyone:
 
----
-## 致谢
-<a href="https://github.com/PapyrusOR/Papyrus_Desktop/contributors">
-  <img src="https://contrib.rocks/image?repo=PapyrusOR/Papyrus_Desktop&max=200&columns=14" />
-</a>
-
-感谢你们的支持，Papyrus因为你们而更好！
-
-## 💡 开发者说
-其实这个作品的诞生过程没有那么理想和伟大。
-
-为什么要做这个呢？有一天我在搞AI学习，下了个Anki准备背记知识点，下完发现这玩意要检查更新，更新要连服务器，我死活连不上。
-
-这时候发现Gemini在旁边呢，让它给我写一个吧，然后写了写调了调，就拿去用了。
-
-其实我本来没想发这个东西的，为啥还是发了呢？
-
-昨天我用上好久没上的号给女朋友点star，github把我识别成机器人，把我的活动下了。我火大啊，我自己用AI，我自己又不是AI，为了证明我不是AI，刚好手里有这个，就改了改放上来了。
-
-小故事讲完了，今天都初六了，过会都天亮了。苦逼学生，哎，只能在这发发牢骚。
-
-我很喜欢一句话：知识使人自由(Veritas vos liberabit)，与各位大佬共勉，这是我的第一个开源项目，望大佬们多多海涵。
-
-就当是拜个晚年吧。
-**祝你在新的一年，手持知识之利刃，刺破黑夜之墟，直捣黎明之境。**
+- **Keyboard navigation** — full Tab traversal across every page.
+- **Screen readers** — semantic ARIA labels, live regions for state changes.
+- **Contrast** — AAA-grade palettes available under **Settings → Accessibility**.
+- **Motion** — reduced-motion mode honors OS preference.
 
 ---
 
-## 📚 文档导航
+## 🛠️ Architecture
 
-- [快速启动指南](docs/guides/QUICKSTART.md) - 5分钟上手
-- [版本信息](docs/guides/VERSION.md) - 当前版本和更新内容
-- [更新日志](docs/guides/CHANGELOG.md) - 完整的版本历史
-- [项目结构](docs/PROJECT_STRUCTURE.md) - 代码组织说明
-- [AI功能说明](docs/AI_README.md) - AI助手使用指南
-- [AI工具演示](docs/AI_TOOLS_DEMO.md) - 实际使用案例
+```
+Papyrus/
+├── backend/                  # Node.js + TypeScript (Fastify)
+│   └── src/
+│       ├── api/              # Fastify routes & server entry (server.ts)
+│       ├── core/             # Cards, notes, SM-2, versioning, crypto
+│       ├── db/               # JSON persistence + migrations
+│       ├── ai/               # Provider abstraction, tool manager, LLM cache
+│       ├── mcp/              # MCP REST endpoints (notes / vault CRUD)
+│       ├── integrations/     # Obsidian import, file watcher (chokidar)
+│       └── utils/            # Shared utilities
+├── frontend/                 # React 19 + TypeScript (Vite)
+│   └── src/
+│       ├── StartPage/        # Home (recent notes, review queue, solar terms)
+│       ├── ScrollPage/       # Flashcard study (the "scroll")
+│       ├── NotesPage/        # Notes management & graph view
+│       ├── SettingsPage/     # Settings, AI config, accessibility
+│       └── ChartsPage/       # Stats & progress charts
+├── electron/                 # Main process + preload (Electron 41)
+├── scripts/                  # build-electron.js, extract-changelog.js
+├── e2e/                      # Playwright E2E tests
+└── docs/                     # Project documentation
+```
 
+### Stack
+
+- **Backend** — Node.js 24, TypeScript 5, Fastify 5, Jest
+- **Frontend** — React 19, TypeScript 5, Vite, Arco Design, Tailwind CSS
+- **Desktop** — Electron 41 + electron-builder
+- **Algorithm** — SM-2 spaced repetition
+- **Storage** — local JSON files, content-hashed versions
+- **CI/CD** — GitHub Actions matrix (Windows x64, macOS arm64, Linux x64)
+
+---
+
+## 🔧 Development
+
+### Backend
+
+```bash
+cd backend
+npm run dev         # tsx watch — hot-reload Fastify
+npm run build       # compile TypeScript to dist/
+npm run typecheck   # tsc --noEmit
+npm test            # Jest unit + integration
+npm start           # run compiled dist/api/server.js
+```
+
+The backend listens on `127.0.0.1:8000` by default; override with `PAPYRUS_PORT`.
+
+### Frontend
+
+```bash
+cd frontend
+npm run dev         # Vite dev server (http://localhost:5173)
+npm run build       # production build to dist/
+npm run typecheck   # TypeScript type-checking
+```
+
+### Release flow
+
+```bash
+# 1. Move [Unreleased] entries in CHANGELOG.md under the new version
+
+# 2. (optional) preview the section that will land in the GitHub Release
+node scripts/extract-changelog.js v2.0.0
+
+# 3. Commit
+git add CHANGELOG.md
+git commit -m "chore: release v2.0.0"
+
+# 4. Tag & push — GitHub Actions builds all three platforms,
+#    extracts the matching CHANGELOG section, and uploads installers.
+git tag v2.0.0
+git push origin main --tags
+```
+
+---
+
+## 📁 Data Files
+
+By default, user data lives under `paths.dataDir` (defaults to `$HOME/PapyrusData`, override with `PAPYRUS_DATA_DIR`):
+
+- `ai_config.json` — provider, model, encrypted API keys
+- `Papyrusdata.json` — cards & SM-2 review state
+- `notes.json` — notes
+- `~/.papyrus/auth.token` — token required for write APIs (generated on first run)
+
+---
+
+## ⚠️ Notes
+
+1. **API costs** — OpenAI and Anthropic bill per use; set provider-side budgets.
+2. **Local models** — Ollama is free but needs decent hardware.
+3. **Network** — cloud providers need a stable connection.
+4. **Privacy** — local models stay local; cloud providers see the prompts you send.
+5. **Concurrency** — JSON-file storage is single-writer; don't run multiple instances against the same data dir.
+
+---
+
+## 📚 Documentation
+
+### User guides
+- [Quick Start](docs/guides/QUICKSTART.md) — 5-minute onboarding
+- [Accessibility settings](docs/guides/A11Y_SETTINGS.md)
+- [Version info](docs/guides/VERSION.md)
+- [Changelog](CHANGELOG.md) — synced into GitHub Releases
+
+### Developer guides
+- [Project structure](docs/PROJECT_STRUCTURE.md)
+- [Environment requirements](docs/guides/ENVIRONMENT_REQUIREMENTS.md)
+- [Accessibility development](docs/guides/ACCESSIBILITY_GUIDE.md)
+- [UI design tokens](docs/guides/UI_TOKENS.md)
+- [REST API reference](docs/API.md)
+- [Extension development](docs/EXTENSIONS.md) and [extension template](examples/extension-template/)
+- [Electron packaging](ELECTRON.md)
+- [Dev environment](README-DEV.md)
+
+### AI features
+- [AI overview](docs/AI_README.md)
+- [AI tools demo](docs/AI_TOOLS_DEMO.md)
+- [Tool-call approval design](docs/tool_call_approval.md)
+
+---
+
+## 💡 A Word from the Author
+
+Honestly, the birth of this project wasn't all that grand or visionary.
+
+Why did I make it? One day I was drilling some AI material and downloaded Anki to memorize the key points. Right after install, the thing wanted to check for updates, the updates wanted to talk to a server, and I just could not get a connection through.
+
+Gemini was sitting right there. So I told it to write me one. We tinkered, I patched, and I started using it.
+
+I never planned to publish it. So why did I?
+
+Yesterday I logged into a long-dormant account to give my girlfriend a star, and GitHub flagged me as a bot and wiped my activity. I was furious. I'm using AI; I'm not AI. To prove I'm not a bot, I cleaned up what I had on hand and put it up here.
+
+End of small story. It's already the sixth day of the lunar new year, and dawn is creeping up. A grumbling student, sighing at three in the morning. Such is life.
+
+There's a phrase I love: **Veritas vos liberabit** — "the truth shall set you free." May we all share in it. This is my first open-source project; please be kind.
+
+Consider this my belated lunar new-year greeting.
+**May the new year find you wielding the blade of knowledge — slicing through the void of night, charging straight into the dawn.**
+
+---
+
+## 📄 License
+
+[MIT](LICENSE)
+
+---
+
+**Papyrus** — make learning smarter, make memory scientific.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 [English](README.md) · **简体中文** · [日本語](README.ja.md)
 
-> ⚠️ **预览版 README** — 本版本描述的是即将到来的 **`v2.0.0-beta.3`**(TypeScript / Fastify 后端)。`main` 上的代码仍是旧的 Python 版本。本文件通过 PR 先于后端重写合并 —— 文中提到的特性与安装方式仅在后端重写合入 `main` 后才适用。
+> ⚠️ **预览版 README** — 本版本描述的是即将到来的 **`v2.0.0`**(TypeScript / Fastify 后端)。`main` 上的代码仍是旧的 Python 版本。本文件通过 PR 先于后端重写合并 —— 文中提到的特性与安装方式仅在后端重写合入 `main` 后才适用。
 
 ![Version](https://img.shields.io/badge/version-v2.0.0--beta.3-blue)
 ![Node.js](https://img.shields.io/badge/Node.js-24-339933)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,314 @@
+# 📜 Papyrus(莎草纸)
+
+[English](README.md) · **简体中文** · [日本語](README.ja.md)
+
+> ⚠️ **预览版 README** — 本版本描述的是即将到来的 **`v2.0.0-beta.3`**(TypeScript / Fastify 后端)。`main` 上的代码仍是旧的 Python 版本。本文件通过 PR 先于后端重写合并 —— 文中提到的特性与安装方式仅在后端重写合入 `main` 后才适用。
+
+![Version](https://img.shields.io/badge/version-v2.0.0--beta.3-blue)
+![Node.js](https://img.shields.io/badge/Node.js-24-339933)
+![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6)
+![Fastify](https://img.shields.io/badge/Fastify-5-000000)
+![React](https://img.shields.io/badge/React-19-61DAFB)
+![Electron](https://img.shields.io/badge/Electron-41-47848F)
+![License](https://img.shields.io/badge/License-MIT-yellow)
+![AI-Assisted](https://img.shields.io/badge/Dev-AI--Assisted-blueviolet)
+![Accessibility](https://img.shields.io/badge/a11y-WCAG%202.1%20AA%2FAAA-green)
+
+**Papyrus** 是一款专注于高强度记忆训练的极简、全键盘驱动、AI Agent 加持的间隔重复(SRS)复习引擎。
+
+> "大道至简。"
+
+---
+
+## ✨ 核心特性
+
+- 🚀 **心流交互** — 全流程键盘驱动,复习时手不离键盘。
+- 🧠 **可靠调度** — 内置 SM-2 间隔重复算法,按掌握程度自动安排下一次复习。
+- 🤖 **AI Agent** — 支持 OpenAI / Anthropic / Ollama,带工具调用审批流(手动/自动)与调用历史。
+- 📝 **笔记 + Obsidian 导入** — 直接接入现有 Vault,支持目录树、标签、关系图。
+- 🕘 **版本历史与回滚** — 笔记/卡片每次编辑自动保存内容哈希版本;回滚生成新版本(无破坏性修改)。
+- 🔐 **API Key 加密落盘** — AES-GCM,每个安装独立的主密钥、盐与认证标签。
+- 🛡️ **默认安全** — 写接口强制 auth token,云端 AI base URL 启用 SSRF 防护,公开接口加 rate limiting,路径遍历用 `dev`+`ino` 容器化校验。
+- ♿ **无障碍** — 全站 WCAG 2.1 AA,提供 AAA 级对比度方案、屏幕阅读器优化、减少动画模式。
+- 🌐 **现代架构** — Node.js + TypeScript(Fastify)后端,React 19 + Vite + Arco Design 前端,Electron 41 桌面壳。
+- 📦 **本地优先** — 数据本地存储;只有当你主动指向云端 AI 提供商时,数据才会出本机。
+
+---
+
+## 📥 下载
+
+预构建安装包发布在 [Releases](https://github.com/PapyrusOR/Papyrus_Desktop/releases) 页面。
+
+| 平台 | 架构 | 格式 |
+| :--- | :--- | :--- |
+| Windows | x64 | NSIS 安装程序(`.exe`)、便携版(`.exe`) |
+| macOS | arm64 | DMG(`.dmg`)、ZIP(`.zip`) |
+| Linux | x64 | AppImage、DEB(`.deb`)、TAR.GZ |
+
+> ⚠️ `v2.0.0-beta.3` 是 beta 版本。数据结构已稳定,但 UI 与 API 在 `v2.0.0` 正式版前仍可能调整。
+
+---
+
+## ⌨️ 快捷键(心流模式)
+
+| 按键 | 动作 | 效果 |
+| :--- | :--- | :--- |
+| **空格** | **揭晓答案** | 展开卷轴,查看"卷尾"内容 |
+| **1** | **忘记** | 标记为不熟悉,短期内高频重现 |
+| **2** | **模糊** | 标记为不确定,稍后再次复习 |
+| **3** | **秒杀** | 记忆稳固,复习间隔线性翻倍 |
+| **Tab** | **导航** | 在可交互元素间切换焦点 |
+| **Ctrl + K** | **搜索** | 打开全局搜索 |
+
+---
+
+## 🚀 快速开始(从源码运行)
+
+### 环境要求
+
+- **Node.js** 24+
+- **npm** 11+
+
+### 安装依赖
+
+```bash
+# postinstall 会自动级联安装 frontend/ 和 backend/
+npm install
+```
+
+### 启动开发模式
+
+```bash
+# 并发运行 backend(Fastify, tsx watch)+ frontend(Vite)
+npm run dev
+
+# 或者带上 Electron 一起拉起
+npm run electron:dev
+```
+
+- 前端:<http://localhost:5173>
+- 后端 API:<http://127.0.0.1:8000>
+- 健康检查:<http://127.0.0.1:8000/api/health>
+
+### 构建安装包
+
+```bash
+npm run electron:build          # 当前平台
+npm run electron:build:win      # 仅 Windows
+npm run electron:build:mac      # 仅 macOS
+npm run electron:build:linux    # 仅 Linux
+```
+
+产物输出到 `dist-electron/`。
+
+---
+
+## 📥 批量导入卡片
+
+准备一个 UTF-8 编码的 `.txt` 文件,格式如下:
+
+```text
+模型场景或问题 A === 核心扳机或答案 A
+
+模型场景或问题 B === 核心扳机或答案 B
+```
+
+> 每组卡片用 `===` 分隔,组与组之间建议空一行以保持清晰。
+
+---
+
+## 🤖 AI 配置
+
+### 1. 配置提供商
+
+点击侧边栏的 **⚙️ 设置**,添加 API Key:
+
+- **OpenAI** — 在 <https://platform.openai.com/api-keys> 获取
+- **Anthropic** — 在 <https://console.anthropic.com/> 获取
+- **Ollama** — 本地运行,无需 API Key
+  ```bash
+  # 下载: https://ollama.ai
+  ollama pull llama2
+  ```
+
+API Key **加密落盘**(AES-GCM,每个安装独立主密钥)。
+
+### 2. 选择模式
+
+- **Agent 模式** — 模型可在工具调用审批流下使用工具(增/删/改卡片、搜索笔记等)。
+- **Chat 模式** — 纯对话,无副作用。
+
+### 3. 参数调整
+
+- **Temperature** — 0~2,越高越随机。
+- **Max Tokens** — 单次回复长度上限。
+- **工具审批** — `manual`(队列审核)或 `auto`(白名单驱动)。
+
+---
+
+## ♿ 无障碍
+
+Papyrus 致力于让所有人都能使用:
+
+- **键盘导航** — 全页面 Tab 顺畅穿梭。
+- **屏幕阅读器** — 语义化 ARIA 标签,状态变化有 live region 朗读。
+- **对比度** — **设置 → 无障碍** 提供 AAA 级配色方案。
+- **动画** — 减少动画模式跟随系统偏好。
+
+---
+
+## 🛠️ 技术架构
+
+```
+Papyrus/
+├── backend/                  # Node.js + TypeScript(Fastify)
+│   └── src/
+│       ├── api/              # Fastify 路由与服务器入口(server.ts)
+│       ├── core/             # 卡片、笔记、SM-2、版本管理、加密
+│       ├── db/               # JSON 持久化与迁移
+│       ├── ai/               # 提供商抽象、工具管理器、LLM 缓存
+│       ├── mcp/              # MCP REST 接口(笔记/Vault CRUD)
+│       ├── integrations/     # Obsidian 导入、文件监听(chokidar)
+│       └── utils/            # 通用工具
+├── frontend/                 # React 19 + TypeScript(Vite)
+│   └── src/
+│       ├── StartPage/        # 首页(最近笔记、复习队列、节气主题)
+│       ├── ScrollPage/       # 卷轴复习页
+│       ├── NotesPage/        # 笔记管理与关系图
+│       ├── SettingsPage/     # 设置、AI 配置、无障碍
+│       └── ChartsPage/       # 统计与进度图表
+├── electron/                 # Electron 41 主进程 + preload
+├── scripts/                  # build-electron.js、extract-changelog.js
+├── e2e/                      # Playwright 端到端测试
+└── docs/                     # 项目文档
+```
+
+### 技术栈
+
+- **后端** — Node.js 24、TypeScript 5、Fastify 5、Jest
+- **前端** — React 19、TypeScript 5、Vite、Arco Design、Tailwind CSS
+- **桌面** — Electron 41 + electron-builder
+- **算法** — SM-2 间隔重复
+- **存储** — 本地 JSON 文件,内容哈希版本
+- **CI/CD** — GitHub Actions 三平台矩阵(Windows x64、macOS arm64、Linux x64)
+
+---
+
+## 🔧 开发说明
+
+### 后端
+
+```bash
+cd backend
+npm run dev         # tsx watch 热重载 Fastify
+npm run build       # 编译 TypeScript 到 dist/
+npm run typecheck   # tsc --noEmit
+npm test            # Jest 单元 + 集成测试
+npm start           # 运行编译后的 dist/api/server.js
+```
+
+后端默认监听 `127.0.0.1:8000`,可通过 `PAPYRUS_PORT` 覆盖。
+
+### 前端
+
+```bash
+cd frontend
+npm run dev         # Vite 开发服务器(http://localhost:5173)
+npm run build       # 生产构建到 dist/
+npm run typecheck   # TypeScript 类型检查
+```
+
+### 发布流程
+
+```bash
+# 1. 把 CHANGELOG.md 中 [Unreleased] 的内容归档到新版本号下
+
+# 2. (可选)预览将进入 GitHub Release 的 changelog 节
+node scripts/extract-changelog.js v2.0.0
+
+# 3. 提交
+git add CHANGELOG.md
+git commit -m "chore: release v2.0.0"
+
+# 4. 打 tag 并推送 — GitHub Actions 会构建三平台、
+#    提取对应版本的 CHANGELOG 节、上传安装包。
+git tag v2.0.0
+git push origin main --tags
+```
+
+---
+
+## 📁 数据文件
+
+默认情况下,用户数据存放在 `paths.dataDir`(默认值 `$HOME/PapyrusData`,可用 `PAPYRUS_DATA_DIR` 覆盖):
+
+- `ai_config.json` — 提供商、模型、加密的 API Key
+- `Papyrusdata.json` — 卡片与 SM-2 复习状态
+- `notes.json` — 笔记
+- `~/.papyrus/auth.token` — 写接口所需的 token(首次运行自动生成)
+
+---
+
+## ⚠️ 注意事项
+
+1. **API 费用** — OpenAI 与 Anthropic 按调用量计费,建议在提供商侧设置预算。
+2. **本地模型** — Ollama 完全免费,但需要较好硬件。
+3. **网络** — 云端提供商需要稳定网络。
+4. **隐私** — 本地模型留在本地;云端提供商会看到你发出的内容。
+5. **并发** — JSON 文件存储为单写入者,不要在同一数据目录同时跑多个实例。
+
+---
+
+## 📚 文档
+
+### 用户指南
+- [快速启动指南](docs/guides/QUICKSTART.md) — 5 分钟上手
+- [无障碍设置](docs/guides/A11Y_SETTINGS.md)
+- [版本信息](docs/guides/VERSION.md)
+- [更新日志](CHANGELOG.md) — 自动同步到 GitHub Release
+
+### 开发指南
+- [项目结构](docs/PROJECT_STRUCTURE.md)
+- [环境要求](docs/guides/ENVIRONMENT_REQUIREMENTS.md)
+- [无障碍开发指南](docs/guides/ACCESSIBILITY_GUIDE.md)
+- [UI 设计变量](docs/guides/UI_TOKENS.md)
+- [REST API 参考](docs/API.md)
+- [扩展开发指南](docs/EXTENSIONS.md) 与 [扩展模板](examples/extension-template/)
+- [Electron 打包](ELECTRON.md)
+- [开发环境](README-DEV.md)
+
+### AI 功能
+- [AI 概述](docs/AI_README.md)
+- [AI 工具演示](docs/AI_TOOLS_DEMO.md)
+- [工具调用审批设计](docs/tool_call_approval.md)
+
+---
+
+## 💡 开发者说
+
+其实这个作品的诞生过程没有那么理想和伟大。
+
+为什么要做这个呢?有一天我在搞 AI 学习,下了个 Anki 准备背记知识点,下完发现这玩意要检查更新,更新要连服务器,我死活连不上。
+
+这时候发现 Gemini 在旁边呢,让它给我写一个吧,然后写了写调了调,就拿去用了。
+
+其实我本来没想发这个东西的,为啥还是发了呢?
+
+昨天我用上好久没上的号给女朋友点 star,github 把我识别成机器人,把我的活动下了。我火大啊,我自己用 AI,我自己又不是 AI,为了证明我不是 AI,刚好手里有这个,就改了改放上来了。
+
+小故事讲完了,今天都初六了,过会都天亮了。苦逼学生,哎,只能在这发发牢骚。
+
+我很喜欢一句话:知识使人自由(Veritas vos liberabit),与各位大佬共勉,这是我的第一个开源项目,望大佬们多多海涵。
+
+就当是拜个晚年吧。
+**祝你在新的一年,手持知识之利刃,刺破黑夜之墟,直捣黎明之境。**
+
+---
+
+## 📄 开源协议
+
+[MIT](LICENSE)
+
+---
+
+**Papyrus** — 让学习更智能,让记忆更科学。


### PR DESCRIPTION
…eta.3 preview banner

- Introduce English / 简体中文 / 日本語 README versions with a top-line language switcher
- Add a preview banner clarifying that this README describes v2.0.0-beta.3 (TS / Fastify) while main is still on the legacy Python build
- Content covers SM-2, AI agent (OpenAI / Anthropic / Ollama), Obsidian import, version history, encrypted API keys, auth-token write gate, rate limiting, SSRF guard
- Includes Releases download table and three-platform CI/CD note