### PR TITLE
Set up dev environment + add AGENTS.md (Cursor Cloud notes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo currently is
+
+The code on `main` is the **legacy Python desktop build** of Papyrus, a
+keyboard-driven spaced-repetition (SRS) flashcard study app built with
+**tkinter**. Data is stored in local JSON files under `data/` (git-ignored).
+
+> Note: `README.md` documents an *unreleased* v2.0.0 rewrite
+> (TypeScript / Fastify / React / Electron). That code does **not** exist on
+> `main` yet — ignore its Node/npm/Vite instructions when working on the
+> current codebase.
+
+### Runtime / dependencies
+
+- Python 3 (CI pins 3.10; the cloud VM runs 3.12 and works fine — code is
+  stdlib + `requests` only).
+- The only pip dependency is `requests` (see `requirements.txt`); the update
+  script installs it.
+- `tkinter` is a **system** dependency (`python3-tk`, already installed in the
+  VM snapshot). It is not a pip package, so it is intentionally **not** in the
+  update script. If a future VM lacks it, install with
+  `sudo apt-get install -y python3-tk`.
+
+### Running the app (GUI)
+
+- The GUI needs an X display. The cloud VM already provides one at `DISPLAY=:1`,
+  so run: `DISPLAY=:1 python3 run.pyw` (launcher) — do not rely on `$DISPLAY`
+  being pre-exported in every shell.
+- `run.pyw` chdir's to the repo root, adds `src/` to `sys.path`, and executes
+  `src/Papyrus.py`. The app auto-starts an in-process **MCP HTTP server** on
+  `127.0.0.1:9100` (daemon thread; health check: `curl 127.0.0.1:9100/health`).
+
+### Testing
+
+- Run the suite with `python3 -m unittest discover -s tests` (uses stdlib
+  `unittest`; `pytest` is not required/installed). Tests mock tkinter, so they
+  run headless without a display.
+
+### Gotchas
+
+- On startup the app opens modal dialogs (AI Assistant / Settings) over the main
+  window. When driving the UI, dismiss/handle those first, or interact via the
+  top menu bar (`操作` = Operations → create card). The UI is mostly in Chinese.
+- Card state persists in `data/Papyrusdata.json`. A reviewed card is scheduled
+  ~1 day out, so it won't be "due" again the same day (main screen shows
+  "今日任务已完成！"). For a fresh demo, delete `data/Papyrusdata.json` before
+  launching (the `data/` dir is git-ignored and recreated automatically).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the current **legacy Python (tkinter)** Papyrus build on `main` and documents it for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering runtime deps, how to run the GUI (`DISPLAY=:1 python3 run.pyw`), the in-process MCP server on `:9100`, the test command, and non-obvious startup gotchas.
- No application code changed.

### Environment

- System dep `python3-tk` installed into the VM (tkinter is not a pip package, so it's intentionally kept out of the update script).
- Update script: `pip install -r requirements.txt` (only pip dep is `requests`).

> Note: `README.md` describes an unreleased v2.0.0 Node/TS rewrite that does not exist on `main`; the actual code is the Python desktop app.

## Testing

- ✅ `python3 -m unittest discover -s tests` — 102 tests pass.
- ✅ Launched the GUI (`DISPLAY=:1 python3 run.pyw`); MCP health check `curl 127.0.0.1:9100/health` returns `{"status": "ok"}`.
- ✅ Hello-world: created a flashcard ("What is 2 + 2?" → "4") via the Operations menu, entered review mode, revealed the answer with Space, and graded it (Aced), reaching the "tasks completed" screen.

### Walkthrough

[papyrus_create_and_review_card-2.mp4](https://cursor.com/agents/bc-9ba0412c-419c-4898-ad38-fa82d88a3eef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpapyrus_create_and_review_card-2.mp4)

Creating and reviewing a flashcard end-to-end.

[Review mode showing question](https://cursor.com/agents/bc-9ba0412c-419c-4898-ad38-fa82d88a3eef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpapyrus_review_question.webp)
[Answer revealed with grading options](https://cursor.com/agents/bc-9ba0412c-419c-4898-ad38-fa82d88a3eef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpapyrus_answer_revealed.webp)
[Review completed](https://cursor.com/agents/bc-9ba0412c-419c-4898-ad38-fa82d88a3eef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpapyrus_review_complete.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ba0412c-419c-4898-ad38-fa82d88a3eef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ba0412c-419c-4898-ad38-fa82d88a3eef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

