### PR TITLE
fix(security): harden API auth, SSRF, and key exposure

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1254,9 +1254,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1272,9 +1269,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1292,9 +1286,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1310,9 +1301,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1330,9 +1318,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1348,9 +1333,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1368,9 +1350,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1387,9 +1366,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1405,9 +1381,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1431,9 +1404,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1455,9 +1425,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1481,9 +1448,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1505,9 +1469,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1531,9 +1492,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1556,9 +1514,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1580,9 +1535,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/backend/src/ai/provider.ts
+++ b/backend/src/ai/provider.ts
@@ -10,6 +10,7 @@ import { LLMCache } from './llm-cache.js';
 import { getProviderConfigFromDB } from './db-sync.js';
 import { getClientId } from '../utils/client-id.js';
 import { fetchWithProxy } from '../utils/proxy.js';
+import { validateProviderBaseUrl } from '../utils/provider-security.js';
 import { PapyrusTools } from './tools.js';
 import type { OpenAIToolDef } from './tools.js';
 import {
@@ -1009,8 +1010,9 @@ Output only the translation, no explanations.`;
     const baseUrl = providerName === 'gemini' ? `${rawBaseUrl}/openai` : rawBaseUrl;
     const apiKey = providerConfig.api_key || '';
 
-    if (isPrivateUrl(rawBaseUrl)) {
-      throw new Error('SSRF: 禁止通过非本地 provider 访问私有地址');
+    const urlError = validateProviderBaseUrl(rawBaseUrl, providerName);
+    if (urlError) {
+      throw new Error(urlError);
     }
 
     // Enforce HTTPS for non-local providers to protect API keys in transit
@@ -1148,6 +1150,10 @@ Output only the translation, no explanations.`;
     providerConfig: { base_url: string },
     mode?: string,
   ): AsyncGenerator<StreamChunk> {
+    const urlError = validateProviderBaseUrl(providerConfig.base_url, 'ollama');
+    if (urlError) {
+      throw new Error(urlError);
+    }
     const baseUrl = providerConfig.base_url.replace(/\/$/, '');
 
     const enrichedMessages = mode === 'agent'

--- a/backend/src/ai/tools.ts
+++ b/backend/src/ai/tools.ts
@@ -1,5 +1,6 @@
 export {
   PapyrusTools,
+  PapyrusTools as CardTools,
   AIResponseParser,
   TOOL_REGISTRY,
   TOOL_LIST,

--- a/backend/src/ai/tools/files.ts
+++ b/backend/src/ai/tools/files.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { listFiles, getFileById } from '../../core/files.js';
+import { listFiles, getFileById, isSafeFileStoragePath } from '../../core/files.js';
 import type { ToolDescriptor } from './types.js';
 import { requireId, isErr } from './types.js';
 
@@ -86,6 +86,9 @@ export const FILE_TOOLS: ToolDescriptor[] = [
       if (file.is_folder) return { success: false, error: '不能读取文件夹的内容' };
       if (!file.file_storage_path || !fs.existsSync(file.file_storage_path)) {
         return { success: false, error: '文件存储路径不存在' };
+      }
+      if (!isSafeFileStoragePath(file.file_storage_path)) {
+        return { success: false, error: '文件路径不在允许的存储目录内' };
       }
       if (!isTextMime(file.mime_type)) {
         return { success: false, error: '仅支持文本文件预览', mime_type: file.mime_type };

--- a/backend/src/api/routes/ai-completion.ts
+++ b/backend/src/api/routes/ai-completion.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { aiConfig } from '../../ai/config-instance.js';
 import { getProviderConfigFromDB, loadAIConfigFromDb } from '../../ai/db-sync.js';
-import { isPrivateUrl } from '../../ai/config.js';
+import { validateProviderBaseUrl } from '../../utils/provider-security.js';
 import { fetchWithProxy } from '../../utils/proxy.js';
 import { isKeylessProvider } from './ai-common.js';
 import type { CompletionPayload } from './ai-common.js';
@@ -134,8 +134,9 @@ export default async function aiCompletionRoutes(fastify: FastifyInstance): Prom
         const firstOllamaModel = providerConfig.models?.[0] ?? '';
         const model = aiConfig.config.current_model || firstOllamaModel;
 
-        if (isPrivateUrl(baseUrl)) {
-          reply.raw.write(`data: {"error":"SSRF: 禁止通过 Ollama provider 访问私有地址"}\n\n`);
+        const urlError = validateProviderBaseUrl(baseUrl, providerName);
+        if (urlError) {
+          reply.raw.write(`data: {"error":"${urlError}"}\n\n`);
           reply.raw.write(`data: {"done":true}\n\n`);
           reply.raw.end();
           return;
@@ -197,8 +198,9 @@ export default async function aiCompletionRoutes(fastify: FastifyInstance): Prom
           return;
         }
         const baseUrl = providerConfig.base_url || 'https://api.openai.com/v1';
-        if (isPrivateUrl(baseUrl)) {
-          reply.raw.write(`data: {"error":"SSRF: 禁止通过非本地 provider 访问私有地址"}\n\n`);
+        const urlError = validateProviderBaseUrl(baseUrl, providerName);
+        if (urlError) {
+          reply.raw.write(`data: {"error":"${urlError}"}\n\n`);
           reply.raw.write(`data: {"done":true}\n\n`);
           reply.raw.end();
           return;

--- a/backend/src/api/routes/ai-config.ts
+++ b/backend/src/api/routes/ai-config.ts
@@ -2,26 +2,25 @@ import type { FastifyInstance } from 'fastify';
 import { aiConfig } from '../../ai/config-instance.js';
 import { isPrivateUrl } from '../../ai/config.js';
 import { getProviderApiKeyFromDB, getProviderConfigFromDB, loadAIConfigFromDb } from '../../ai/db-sync.js';
-import { loadAllProviders } from '../../db/database.js';
+import { loadAllProvidersForClient } from '../../db/database.js';
 import { fetchWithProxy } from '../../utils/proxy.js';
 import { isKeylessProvider } from './ai-common.js';
 import type { AIConfigPayload } from './ai-common.js';
+import { validateProviderBaseUrl } from '../../utils/provider-security.js';
 
 export default async function aiConfigRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.get('/config/ai', async (request, reply) => {
     const masked = aiConfig.getMaskedConfig();
-    const dbProviders = loadAllProviders();
+    const dbProviders = loadAllProvidersForClient();
     const providersFromDB: Record<string, { api_key: string; base_url: string; models: string[] }> = {};
     for (const p of dbProviders) {
       if (providersFromDB[p.type]) {
         request.log.warn(`Duplicate provider type "${p.type}" found in database; using first occurrence`);
         continue;
       }
-      const firstKey = p.apiKeys.find((k) => k.key.trim() !== '');
+      const firstKey = p.apiKeys.find((k) => k.hasKey || k.key.trim() !== '');
       providersFromDB[p.type] = {
-        api_key: firstKey?.key
-          ? '*'.repeat(firstKey.key.length - 4) + firstKey.key.slice(-4)
-          : '',
+        api_key: firstKey?.key ?? '',
         base_url: p.baseUrl ?? '',
         models: p.models.filter((m) => m.enabled).map((m) => m.modelId),
       };
@@ -100,6 +99,11 @@ export default async function aiConfigRoutes(fastify: FastifyInstance): Promise<
           reply.send({ success: false, error: 'Base URL 未设置' });
           return;
         }
+        const urlError = validateProviderBaseUrl(baseUrl, providerName);
+        if (urlError) {
+          reply.send({ success: false, error: urlError });
+          return;
+        }
         try {
           // 对于 keyless providers，尝试连接 base URL
           // 不同的 provider 可能有不同的健康检查端点，这里我们做一个简单的 GET 请求
@@ -128,6 +132,11 @@ export default async function aiConfigRoutes(fastify: FastifyInstance): Promise<
       const baseUrl = providerConfig.base_url;
       if (!baseUrl) {
         reply.send({ success: false, error: 'Base URL 未设置' });
+        return;
+      }
+      const urlError = validateProviderBaseUrl(baseUrl, providerName);
+      if (urlError) {
+        reply.send({ success: false, error: urlError });
         return;
       }
       if (isPrivateUrl(baseUrl)) {

--- a/backend/src/api/routes/files.ts
+++ b/backend/src/api/routes/files.ts
@@ -5,6 +5,12 @@ import { listFiles, createFolder, saveFile, deleteFileItem, getFileById, isSafeF
 
 const MAX_PREVIEW_SIZE = 10 * 1024 * 1024;
 const THUMBNAIL_SIZE = 128;
+const INLINE_PREVIEW_PREFIXES = ['image/', 'text/'];
+
+function shouldServeInline(mimeType: string | null | undefined): boolean {
+  if (!mimeType) return false;
+  return INLINE_PREVIEW_PREFIXES.some((prefix) => mimeType.startsWith(prefix));
+}
 
 export default async function filesRoutes(fastify: FastifyInstance): Promise<void> {
   // List all files/folders
@@ -105,7 +111,12 @@ export default async function filesRoutes(fastify: FastifyInstance): Promise<voi
 
     const content = fs.readFileSync(file.file_storage_path);
     reply.type(file.mime_type || 'application/octet-stream');
-    reply.header('Content-Disposition', 'inline');
+    if (shouldServeInline(file.mime_type)) {
+      reply.header('Content-Disposition', 'inline');
+      reply.header('Content-Security-Policy', "default-src 'none'; sandbox");
+    } else {
+      reply.header('Content-Disposition', `attachment; filename*=UTF-8''${encodeURIComponent(file.name)}`);
+    }
     reply.header('Content-Length', file.size);
     reply.send(content);
   });

--- a/backend/src/api/routes/notes.ts
+++ b/backend/src/api/routes/notes.ts
@@ -6,6 +6,7 @@ import { getAllNotes, createNote, updateNote, deleteNote, deleteNotes, getNoteBy
 import { importObsidianVault } from '../../core/notes.js';
 import { recordNoteCreated } from '../../core/progress.js';
 import { pushExtensionEvent } from '#/core/extension-events.js';
+import { isPathInsideDirectory } from '../../utils/security.js';
 
 export default async function notesRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.get('/', async (_request, reply) => {
@@ -100,7 +101,7 @@ export default async function notesRoutes(fastify: FastifyInstance): Promise<voi
       return;
     }
     const homeDir = fs.realpathSync(path.resolve(os.homedir()));
-    if (!resolvedVaultPath.startsWith(homeDir + path.sep) && resolvedVaultPath !== homeDir) {
+    if (!isPathInsideDirectory(resolvedVaultPath, homeDir)) {
       reply.status(400).send({ success: false, error: 'Obsidian vault 路径必须在用户主目录下' });
       return;
     }

--- a/backend/src/api/routes/providers.ts
+++ b/backend/src/api/routes/providers.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import {
   loadAllProviders,
+  loadAllProvidersForClient,
   saveProvider,
   deleteProvider,
   setDefaultProvider,
@@ -16,11 +17,13 @@ import { getDb } from '../../db/database.js';
 import type { Provider } from '../../core/types.js';
 import { aiConfig } from '../../ai/config-instance.js';
 import { loadAIConfigFromDb } from '../../ai/db-sync.js';
+import { validateProviderBaseUrl, isMaskedApiKeySubmission } from '../../utils/provider-security.js';
 
 const ApiKeySchema = z.object({
   id: z.string().optional(),
   name: z.string().min(1),
   key: z.string(),
+  hasKey: z.boolean().optional(),
 });
 
 const ModelSchema = z.object({
@@ -37,17 +40,25 @@ const ProviderSchema = z.object({
   id: z.string().optional(),
   type: z.string().optional(),
   name: z.string().min(1),
-  baseUrl: z.string().optional(),
+  baseUrl: z.string().max(2048).optional(),
   enabled: z.boolean().optional(),
   isDefault: z.boolean().optional(),
   apiKeys: z.array(ApiKeySchema).optional(),
   models: z.array(ModelSchema).optional(),
-}).passthrough();
+});
+
+function validateProviderPayload(body: Partial<Provider>): string | null {
+  const providerType = body.type ?? 'custom';
+  if (body.baseUrl) {
+    return validateProviderBaseUrl(body.baseUrl, providerType);
+  }
+  return null;
+}
 
 export default async function providersRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.get('/', async (request, reply) => {
     try {
-      const providers = loadAllProviders();
+      const providers = loadAllProvidersForClient();
       reply.send({ success: true, providers });
     } catch (err) {
       const message = err instanceof Error ? err.message : '服务器内部错误';
@@ -63,12 +74,20 @@ export default async function providersRoutes(fastify: FastifyInstance): Promise
       return;
     }
     const body = parseResult.data as Partial<Provider>;
+    const urlError = validateProviderPayload(body);
+    if (urlError) {
+      reply.status(400).send({ success: false, error: urlError });
+      return;
+    }
     try {
       const id = runInTransaction(() => {
         const providerId = saveProvider(body);
 
         if (body.apiKeys) {
           for (const key of body.apiKeys) {
+            if (isMaskedApiKeySubmission(key.key)) {
+              continue;
+            }
             saveApiKey(providerId, key);
           }
         }
@@ -107,6 +126,12 @@ export default async function providersRoutes(fastify: FastifyInstance): Promise
         return;
       }
 
+      const urlError = validateProviderPayload({ ...body, type: body.type ?? existingProvider.type });
+      if (urlError) {
+        reply.status(400).send({ success: false, error: urlError });
+        return;
+      }
+
       // 合并请求体与数据库中的现有记录，未显式提供的字段保持原值
       const mergedProvider: Partial<Provider> = {
         ...existingProvider,
@@ -119,8 +144,14 @@ export default async function providersRoutes(fastify: FastifyInstance): Promise
 
         // 仅当请求显式包含 apiKeys 时才同步密钥列表，避免误删现有密钥
         if (body.apiKeys !== undefined) {
-          const incomingKeyIds = new Set(body.apiKeys.map(k => k.id).filter(Boolean) as string[]);
+          const incomingKeyIds = new Set<string>();
           for (const key of body.apiKeys) {
+            if (key.id) {
+              incomingKeyIds.add(key.id);
+            }
+            if (isMaskedApiKeySubmission(key.key)) {
+              continue;
+            }
             const savedKeyId = saveApiKey(providerId, key);
             incomingKeyIds.add(savedKeyId);
           }

--- a/backend/src/api/server.ts
+++ b/backend/src/api/server.ts
@@ -8,7 +8,14 @@ import { PapyrusLogger } from '../utils/logger.js';
 import { MCPServer } from '../mcp/server.js';
 import { startFileWatching, stopFileWatching } from '../integrations/file-watcher.js';
 import { setGlobalLogger } from './routes/logs.js';
-import { isAuthEnabled, validateRequestToken } from '../utils/auth.js';
+import {
+  ensureAuthToken,
+  extractRequestToken,
+  isAuthEnabled,
+  isPublicApiPath,
+  allowsQueryTokenAuth,
+  validateRequestToken,
+} from '../utils/auth.js';
 import { closeDb } from '../db/database.js';
 
 const logger = new PapyrusLogger(
@@ -65,11 +72,14 @@ app.addHook('onSend', async (_request, reply) => {
   reply.header('X-Content-Type-Options', 'nosniff');
   reply.header('X-Frame-Options', 'DENY');
   reply.header('Referrer-Policy', 'strict-origin-when-cross-origin');
+  reply.header('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+  reply.header('Content-Security-Policy', "default-src 'none'; frame-ancestors 'none'");
 });
 
 const PORT = process.env.PAPYRUS_PORT ? parseInt(process.env.PAPYRUS_PORT, 10) : 8000;
 
 export async function initApp(): Promise<void> {
+  ensureAuthToken();
   setGlobalLogger(logger);
   const { initAIConfig, aiConfig } = await import('../ai/config-instance.js');
   initAIConfig();
@@ -114,20 +124,25 @@ export async function initApp(): Promise<void> {
     timeWindow: '1 minute',
   });
 
-  // Optional lightweight auth for local API protection
-  // When PAPYRUS_AUTH_TOKEN is set (Electron mode), require it for mutating operations
+  // Local API protection: require token on all /api routes except /api/health.
   if (isAuthEnabled()) {
     app.addHook('onRequest', async (request, reply) => {
-      if (request.method === 'GET' || request.method === 'HEAD' || request.method === 'OPTIONS') {
+      if (request.method === 'OPTIONS') {
         return;
       }
-      if (request.url === '/api/health') {
+      const requestPath = request.url.split('?')[0] ?? request.url;
+      if (isPublicApiPath(requestPath)) {
         return;
       }
-      const token = request.headers['x-papyrus-token'];
-      if (!validateRequestToken(typeof token === 'string' ? token : undefined)) {
+      if (!requestPath.startsWith('/api/')) {
+        return;
+      }
+
+      const query = request.query as { access_token?: string };
+      const queryToken = allowsQueryTokenAuth(request.url) ? query.access_token : undefined;
+      const token = extractRequestToken(request.headers['x-papyrus-token'], queryToken);
+      if (!validateRequestToken(token)) {
         reply.status(401).send({ success: false, error: 'Unauthorized' });
-        return;
       }
     });
   }
@@ -185,7 +200,8 @@ export async function start(): Promise<void> {
     await app.listen({ port: PORT, host: '127.0.0.1' });
     logger.info(`Papyrus backend started on http://127.0.0.1:${PORT}`);
 
-    mcpServer = new MCPServer({ logger });
+    const { getAuthToken } = await import('../utils/auth.js');
+    mcpServer = new MCPServer({ logger, authToken: getAuthToken() ?? undefined });
     await mcpServer.start();
 
     startFileWatching((eventType, filePath) => {

--- a/backend/src/core/types.ts
+++ b/backend/src/core/types.ts
@@ -53,6 +53,8 @@ export interface ApiKey {
   id: string;
   name: string;
   key: string;
+  /** 读接口脱敏时标记是否已保存密钥（key 字段为掩码或空） */
+  hasKey?: boolean;
 }
 
 export interface Model {

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -6,6 +6,7 @@ import { paths } from '../utils/paths.js';
 import { encryptApiKey, decryptApiKey } from '../core/crypto.js';
 import type { CardRecord, Note, Provider, FileRecord } from '../core/types.js';
 import type { PapyrusLogger } from '../utils/logger.js';
+import { maskApiKeyForDisplay } from '../utils/provider-security.js';
 
 let db: DatabaseSync | null = null;
 
@@ -859,6 +860,88 @@ export function loadAllProviders(_logger?: PapyrusLogger): Provider[] {
   }
 
   // 防御性去重：即使数据库出现重复，输出层也不渲染重复项
+  const seenProviders = new Set<string>();
+  const dedupedProviders: Provider[] = [];
+  for (const p of providers) {
+    const key = `${p.type}|${p.name}|${p.baseUrl}`;
+    if (seenProviders.has(key)) continue;
+    seenProviders.add(key);
+
+    const seenModels = new Set<string>();
+    const dedupedModels = p.models.filter(m => {
+      if (seenModels.has(m.modelId)) return false;
+      seenModels.add(m.modelId);
+      return true;
+    });
+
+    dedupedProviders.push({ ...p, models: dedupedModels });
+  }
+
+  return dedupedProviders;
+}
+
+// 为客户端 API 加载 providers，不回传明文 API Key。
+// 原因：GET /api/providers 曾被未认证客户端直接读取全部密钥。
+// 未复用 loadAllProviders 后脱敏：避免无意义的解密再掩码，降低密钥暴露窗口。
+export function loadAllProvidersForClient(_logger?: PapyrusLogger): Provider[] {
+  const database = getDb();
+  const providerStmt = database.prepare('SELECT * FROM providers ORDER BY created_at');
+  const providerRows = providerStmt.all() as Array<{
+    id: string;
+    type: string;
+    name: string;
+    base_url: string;
+    enabled: number;
+    is_default: number;
+  }>;
+
+  const keyStmt = database.prepare('SELECT id, name, encrypted_key FROM api_keys WHERE provider_id = ? ORDER BY name');
+  const modelStmt = database.prepare('SELECT * FROM provider_models WHERE provider_id = ? ORDER BY name');
+
+  const providers: Provider[] = [];
+  for (const row of providerRows) {
+    const keyRows = keyStmt.all(row.id) as Array<{ id: string; name: string; encrypted_key: string }>;
+    const apiKeys = keyRows.map((k) => {
+      const masked = maskApiKeyForDisplay(Boolean(k.encrypted_key));
+      return {
+        id: k.id,
+        name: k.name,
+        key: masked.key,
+        hasKey: masked.hasKey,
+      };
+    });
+
+    const modelRows = modelStmt.all(row.id) as Array<{
+      id: string;
+      name: string;
+      model_id: string;
+      port: string;
+      capabilities: string;
+      api_key_id: string;
+      enabled: number;
+    }>;
+    const models = modelRows.map(m => ({
+      id: m.id,
+      name: m.name,
+      modelId: m.model_id,
+      port: m.port,
+      capabilities: jsonFromStr(m.capabilities) as string[],
+      apiKeyId: m.api_key_id ?? null,
+      enabled: Boolean(m.enabled),
+    }));
+
+    providers.push({
+      id: row.id,
+      type: row.type,
+      name: row.name,
+      baseUrl: row.base_url,
+      enabled: Boolean(row.enabled),
+      isDefault: Boolean(row.is_default),
+      apiKeys,
+      models,
+    });
+  }
+
   const seenProviders = new Set<string>();
   const dedupedProviders: Provider[] = [];
   for (const p of providers) {

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -76,7 +76,14 @@ export class MCPServer {
           return;
         }
 
+        const authHeader = req.headers.authorization ?? '';
+        const isAuthorized = authHeader === `Bearer ${this.authToken}`;
+
         if (req.method === 'GET' && req.url === '/tools') {
+          if (!isAuthorized) {
+            sendJson(res, { error: 'Unauthorized' }, 401, origin);
+            return;
+          }
           sendJson(res, getMcpToolsCatalog(), 200, origin);
           return;
         }
@@ -86,8 +93,7 @@ export class MCPServer {
           return;
         }
 
-        const authHeader = req.headers.authorization ?? '';
-        if (authHeader !== `Bearer ${this.authToken}`) {
+        if (!isAuthorized) {
           sendJson(res, { error: 'Unauthorized' }, 401, origin);
           return;
         }

--- a/backend/src/mcp/tools.ts
+++ b/backend/src/mcp/tools.ts
@@ -32,7 +32,6 @@ export const MCP_VAULT_TOOLS = [
 export const MCP_CLI_TOOLS = [
   'cli_status',
   'cli_install',
-  'cli_run',
 ];
 
 // 汇总 MCP 工具清单，返回给 Desktop API 与独立 MCP 服务。

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -58,6 +58,39 @@ export function isAuthEnabled(): boolean {
   return !!getAuthToken();
 }
 
+// 判断请求是否属于无需认证的公开端点（仅健康检查）。
+// 原因：桌面应用仍需探活，但其余读写接口都必须绑定本地 token。
+// 未放行 OPTIONS 以外的 GET：此前 GET 豁免导致 API Key 与笔记可被任意本机进程读取。
+export function isPublicApiPath(url: string): boolean {
+  const pathOnly = url.split('?')[0] ?? url;
+  return pathOnly === '/api/health';
+}
+
+// 从请求头或受控 query 参数提取认证 token。
+// 原因：<img>/window.open 无法自定义 Header，文件预览需支持 access_token 查询参数。
+// 未对所有路由开放 query token：仅在文件媒体路由的认证钩子里调用，缩小泄露面。
+export function extractRequestToken(
+  headerToken: string | string[] | undefined,
+  queryAccessToken?: string,
+): string | undefined {
+  if (typeof headerToken === 'string') {
+    return headerToken;
+  }
+  if (Array.isArray(headerToken) && typeof headerToken[0] === 'string') {
+    return headerToken[0];
+  }
+  if (typeof queryAccessToken === 'string' && queryAccessToken.length > 0) {
+    return queryAccessToken;
+  }
+  return undefined;
+}
+
+// 文件预览/缩略图/下载允许通过 query 携带 token，供无法设置 Header 的媒体标签使用。
+export function allowsQueryTokenAuth(url: string): boolean {
+  const pathOnly = url.split('?')[0] ?? url;
+  return /^\/api\/files\/[^/]+\/(preview|thumbnail|download)$/.test(pathOnly);
+}
+
 export function validateRequestToken(headerToken?: string): boolean {
   const expected = getAuthToken();
   if (!expected) {
@@ -72,4 +105,11 @@ export function validateRequestToken(headerToken?: string): boolean {
     return false;
   }
   return timingSafeEqual(bufA, bufB);
+}
+
+// 服务启动时确保本地 API token 存在，避免“未配置 token = 认证关闭”。
+// 原因：开发脚本常单独启动后端，必须自动生成并持久化 token。
+// 未强制依赖 Electron 注入：Electron 仍可覆盖 env token，但 standalone 后端也默认受保护。
+export function ensureAuthToken(): string {
+  return getOrCreateAuthToken();
 }

--- a/backend/src/utils/provider-security.ts
+++ b/backend/src/utils/provider-security.ts
@@ -1,0 +1,62 @@
+import { isPrivateNetworkUrl } from './security.js';
+import { isKeylessProvider } from '../api/routes/ai-common.js';
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1']);
+
+// 判断 provider base URL 是否允许保存或发起请求，返回错误信息或 null。
+// 原因：本地类 provider 仅应访问本机服务，远程 provider 必须阻断私网 SSRF。
+// 未在路由内联判断：集中校验可避免 ai-config、providers、provider.ts 规则漂移。
+export function validateProviderBaseUrl(baseUrl: string, providerType: string): string | null {
+  if (!baseUrl.trim()) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    return '无效的 Base URL';
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return 'Base URL 仅支持 http 或 https';
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (isKeylessProvider(providerType)) {
+    if (!LOCAL_HOSTS.has(hostname)) {
+      return '本地服务商仅允许 localhost 或 127.0.0.1';
+    }
+    return null;
+  }
+
+  if (isPrivateNetworkUrl(baseUrl)) {
+    return 'SSRF: 禁止配置私有网络地址';
+  }
+
+  return null;
+}
+
+// 将 API Key 脱敏为仅保留后四位的占位串，供设置页展示已配置状态。
+// 原因：读接口不能回传明文 key，但仍需让前端区分“未配置”和“已配置”。
+// 未返回空串：空串无法区分“用户主动清空”和“已有密钥被隐藏”。
+export function maskApiKeyForDisplay(encryptedKeyPresent: boolean, decryptedKey?: string): { key: string; hasKey: boolean } {
+  if (!encryptedKeyPresent) {
+    return { key: '', hasKey: false };
+  }
+  if (decryptedKey && decryptedKey.length >= 4) {
+    return { key: '*'.repeat(Math.max(decryptedKey.length - 4, 4)) + decryptedKey.slice(-4), hasKey: true };
+  }
+  return { key: '********', hasKey: true };
+}
+
+// 判断客户端提交的是脱敏占位 key 还是用户新输入的明文 key。
+// 原因：更新 provider 时若把占位串写回数据库，会破坏已保存密钥。
+// 未用空串判断：空串可能表示“保留原值”或“删除密钥”，需结合 hasKey 语义。
+export function isMaskedApiKeySubmission(key: string): boolean {
+  const trimmed = key.trim();
+  if (!trimmed) {
+    return true;
+  }
+  return /^\*+[A-Za-z0-9]{0,4}$/.test(trimmed);
+}

--- a/backend/tests/integration/api.test.ts
+++ b/backend/tests/integration/api.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { app, initApp, logger } from '../../src/api/server.js';
 import { closeDb, saveProvider, saveApiKey, saveModel } from '../../src/db/database.js';
+import { patchAppInjectWithAuth } from '../test-auth.js';
 
 describe('API Integration Tests', () => {
   const testDir = path.join(os.tmpdir(), `papyrus-api-test-${Date.now()}`);
@@ -14,6 +15,7 @@ describe('API Integration Tests', () => {
     const { resetAIConfig } = await import('../../src/ai/config-instance.js');
     resetAIConfig(testDir);
     await initApp();
+    patchAppInjectWithAuth(app);
     logger.setLogDir(path.join(testDir, 'logs'));
     app.post('/api/test-crash', async () => {
       throw new Error('intentional test crash');
@@ -1549,7 +1551,8 @@ describe('API Integration Tests', () => {
       expect(provider?.name).toBe('Updated Provider');
       expect(provider?.enabled).toBe(false);
       expect(provider?.apiKeys.map((item) => item.id)).toEqual(['key-keep']);
-      expect(provider?.apiKeys[0]?.key).toBe('sk-keep-2');
+      expect(provider?.apiKeys[0]?.hasKey).toBe(true);
+      expect(provider?.apiKeys[0]?.key).toMatch(/^\*+$/);
     });
 
     it('POST /api/providers/:providerId/default should set default provider', async () => {
@@ -2264,7 +2267,7 @@ describe('API Integration Tests', () => {
           id: 'provider-ollama-chat',
           type: 'ollama',
           name: 'Ollama Chat',
-          baseUrl: 'https://ollama.example.com',
+          baseUrl: 'http://localhost:11434',
           enabled: true,
           isDefault: true,
           models: [{ id: 'model-ollama-chat', name: 'llama3', modelId: 'llama3', enabled: true }],
@@ -2338,7 +2341,7 @@ describe('API Integration Tests', () => {
           id: 'provider-ollama-regen',
           type: 'ollama',
           name: 'Ollama Regen',
-          baseUrl: 'https://ollama.example.com',
+          baseUrl: 'http://localhost:11434',
           enabled: true,
           isDefault: true,
           models: [{ id: 'model-ollama-regen', name: 'llama3', modelId: 'llama3', enabled: true }],
@@ -2455,7 +2458,7 @@ describe('API Integration Tests', () => {
           id: 'provider-ollama-translate',
           type: 'ollama',
           name: 'Ollama Translate',
-          baseUrl: 'https://ollama.example.com',
+          baseUrl: 'http://localhost:11434',
           enabled: true,
           isDefault: true,
           models: [{ id: 'model-ollama-translate', name: 'llama3', modelId: 'llama3', enabled: true }],
@@ -2531,19 +2534,17 @@ describe('API Integration Tests', () => {
       });
       expect(missingProviderResponse.statusCode).toBe(400);
 
-      await app.inject({
-        method: 'POST',
-        url: '/api/providers',
-        payload: {
-          id: 'provider-openai-private',
-          type: 'openai',
-          name: 'OpenAI Private',
-          baseUrl: 'http://127.0.0.1:9001',
-          enabled: true,
-          apiKeys: [{ id: 'key-openai-private', name: 'default', key: 'sk-private' }],
-          models: [{ id: 'model-openai-private', name: 'gpt-4', modelId: 'gpt-4', enabled: true }],
-        },
+      const { saveProvider, saveApiKey, saveModel } = await import('../../src/db/database.js');
+      const privateProviderId = saveProvider({
+        id: 'provider-openai-private',
+        type: 'openai',
+        name: 'OpenAI Private',
+        baseUrl: 'http://127.0.0.1:9001',
+        enabled: true,
+        isDefault: false,
       });
+      saveApiKey(privateProviderId, { id: 'key-openai-private', name: 'default', key: 'sk-private' });
+      saveModel(privateProviderId, { id: 'model-openai-private', name: 'gpt-4', modelId: 'gpt-4', enabled: true });
       aiConfig.config.current_provider = 'openai';
       aiConfig.config.current_model = 'gpt-4';
 
@@ -2585,7 +2586,7 @@ describe('API Integration Tests', () => {
           id: 'provider-ollama-public-completion',
           type: 'ollama',
           name: 'Ollama Public Completion',
-          baseUrl: 'https://ollama.example.com',
+          baseUrl: 'http://localhost:11434',
           enabled: true,
           models: [{ id: 'model-ollama-public', name: 'llama3', modelId: 'llama3', enabled: true }],
         },
@@ -2631,28 +2632,21 @@ describe('API Integration Tests', () => {
         global.fetch = savedFetch;
       }
 
-      await app.inject({
+      const privateOllamaPutResponse = await app.inject({
         method: 'PUT',
         url: '/api/providers/provider-ollama-public-completion',
         payload: {
           type: 'ollama',
           name: 'Ollama Public Completion',
-          baseUrl: 'http://127.0.0.1:11434',
+          baseUrl: 'http://192.168.1.10:11434',
           enabled: true,
           models: [{ id: 'model-ollama-public', name: 'llama3', modelId: 'llama3', enabled: true }],
         },
       });
 
-      aiConfig.config.current_provider = 'ollama';
-      aiConfig.config.current_model = 'llama3';
-
-      const privateOllamaResponse = await app.inject({
-        method: 'POST',
-        url: '/api/completion',
-        payload: { prefix: 'private ollama' },
-      });
-      expect(privateOllamaResponse.statusCode).toBe(200);
-      expect(privateOllamaResponse.body).toContain('SSRF');
+      expect(privateOllamaPutResponse.statusCode).toBe(400);
+      const privateOllamaBody = JSON.parse(privateOllamaPutResponse.body) as { error?: string };
+      expect(privateOllamaBody.error).toMatch(/localhost|SSRF|本地/);
     });
 
     it('POST /api/completion should end the SSE stream when upstream fetch throws', async () => {
@@ -2663,7 +2657,7 @@ describe('API Integration Tests', () => {
           id: 'provider-ollama-throw-completion',
           type: 'ollama',
           name: 'Ollama Throw Completion',
-          baseUrl: 'https://ollama-throw.example.com',
+          baseUrl: 'http://localhost:11435',
           enabled: true,
           isDefault: true,
           models: [{ id: 'model-ollama-throw', name: 'llama3', modelId: 'llama3', enabled: true }],

--- a/backend/tests/integration/cli-api.test.ts
+++ b/backend/tests/integration/cli-api.test.ts
@@ -1,8 +1,10 @@
 import { app, initApp } from '../../src/api/server.js';
+import { patchAppInjectWithAuth } from '../test-auth.js';
 
 describe('CLI Manager API', () => {
   beforeAll(async () => {
     await initApp();
+    patchAppInjectWithAuth(app);
   });
 
   afterAll(async () => {

--- a/backend/tests/integration/extensions-local.test.ts
+++ b/backend/tests/integration/extensions-local.test.ts
@@ -1,6 +1,7 @@
 import { deflateRawSync } from 'node:zlib';
 import { app, initApp } from '../../src/api/server.js';
 import { closeDb, getDb, insertFile } from '../../src/db/database.js';
+import { patchAppInjectWithAuth } from '../test-auth.js';
 
 function crc32(buffer: Buffer): number {
   let crc = 0xffffffff;
@@ -75,6 +76,7 @@ function createZip(entries: Array<{ name: string; content: string }>): Buffer {
 describe('local extension install and MCP integration', () => {
   beforeAll(async () => {
     await initApp();
+    patchAppInjectWithAuth(app);
   });
 
   beforeEach(() => {

--- a/backend/tests/integration/security-hardening.test.ts
+++ b/backend/tests/integration/security-hardening.test.ts
@@ -1,0 +1,273 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { closeDb, getDb, resetDb, saveApiKey, saveModel, saveProvider } from '../../src/db/database.js';
+import { saveFile } from '../../src/core/files.js';
+import { getMcpToolsCatalog, executeMcpTool } from '../../src/mcp/tools.js';
+import { testAuthHeaders } from '../test-auth.js';
+
+type InjectResponse = {
+  statusCode: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+  json: () => unknown;
+};
+
+type InjectableApp = {
+  inject: (opts: Record<string, unknown>) => Promise<InjectResponse>;
+};
+
+describe('Security Hardening Integration', () => {
+  const testDir = path.join(os.tmpdir(), `papyrus-security-hardening-${Date.now()}`);
+  const authToken = 'security-hardening-token-' + 'z'.repeat(24);
+  let app: InjectableApp;
+  let originalDataDir: string | undefined;
+  let originalAuthToken: string | undefined;
+
+  beforeAll(async () => {
+    fs.mkdirSync(testDir, { recursive: true });
+    originalDataDir = process.env.PAPYRUS_DATA_DIR;
+    originalAuthToken = process.env.PAPYRUS_AUTH_TOKEN;
+    process.env.PAPYRUS_DATA_DIR = testDir;
+    process.env.PAPYRUS_AUTH_TOKEN = authToken;
+    resetDb();
+
+    const serverModule = await import('../../src/api/server.js');
+    await serverModule.initApp();
+    app = serverModule.app as InjectableApp;
+  });
+
+  afterAll(() => {
+    closeDb();
+    try {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+    if (originalDataDir !== undefined) {
+      process.env.PAPYRUS_DATA_DIR = originalDataDir;
+    } else {
+      delete process.env.PAPYRUS_DATA_DIR;
+    }
+    if (originalAuthToken !== undefined) {
+      process.env.PAPYRUS_AUTH_TOKEN = originalAuthToken;
+    } else {
+      delete process.env.PAPYRUS_AUTH_TOKEN;
+    }
+  });
+
+  describe('Authentication boundaries', () => {
+    it('rejects sensitive GET endpoints without token', async () => {
+      const endpoints = ['/api/providers', '/api/export', '/api/notes', '/api/mcp/cards'];
+      for (const url of endpoints) {
+        const response = await app.inject({ method: 'GET', url });
+        expect(response.statusCode).toBe(401);
+      }
+    });
+
+    it('rejects MCP call without token', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/mcp/call',
+        payload: { tool: 'get_card_stats', params: {} },
+      });
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('allows file media routes with access_token query param', async () => {
+      const content = Buffer.from('preview text').toString('base64');
+      const file = saveFile('preview.txt', content, 'text/plain');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/files/${file.id}/preview?access_token=${encodeURIComponent(authToken)}`,
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain('preview text');
+    });
+
+    it('rejects file media routes with invalid access_token', async () => {
+      const content = Buffer.from('secret').toString('base64');
+      const file = saveFile('secret.txt', content, 'text/plain');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/files/${file.id}/preview?access_token=wrong-token-value`,
+      });
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe('Provider API key masking', () => {
+    it('never returns plaintext API keys on GET /api/providers', async () => {
+      const providerId = saveProvider({
+        id: 'sec-provider-mask',
+        type: 'openai',
+        name: 'Mask Test',
+        baseUrl: 'https://api.openai.com/v1',
+        enabled: true,
+        isDefault: false,
+      });
+      saveApiKey(providerId, { id: 'sec-key-1', name: 'default', key: 'sk-super-secret-key-value' });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/providers',
+        headers: testAuthHeaders(),
+      });
+      expect(response.statusCode).toBe(200);
+      const body = response.json() as {
+        providers: Array<{
+          id: string;
+          apiKeys: Array<{ key: string; hasKey?: boolean }>;
+        }>;
+      };
+      const provider = body.providers.find((item) => item.id === providerId);
+      expect(provider).toBeDefined();
+      expect(provider?.apiKeys[0]?.hasKey).toBe(true);
+      expect(provider?.apiKeys[0]?.key).not.toContain('sk-super-secret');
+      expect(provider?.apiKeys[0]?.key).toMatch(/^\*+$/);
+    });
+
+    it('preserves stored API key when update submits masked placeholder', async () => {
+      const providerId = saveProvider({
+        id: 'sec-provider-preserve',
+        type: 'openai',
+        name: 'Preserve Test',
+        baseUrl: 'https://api.openai.com/v1',
+        enabled: true,
+        isDefault: false,
+      });
+      saveApiKey(providerId, { id: 'sec-key-preserve', name: 'default', key: 'sk-original-secret' });
+
+      const updateResponse = await app.inject({
+        method: 'PUT',
+        url: `/api/providers/${providerId}`,
+        headers: testAuthHeaders(),
+        payload: {
+          type: 'openai',
+          name: 'Preserve Test Updated',
+          baseUrl: 'https://api.openai.com/v1',
+          enabled: true,
+          apiKeys: [{ id: 'sec-key-preserve', name: 'default', key: '********cret', hasKey: true }],
+        },
+      });
+      expect(updateResponse.statusCode).toBe(200);
+
+      const row = getDb()
+        .prepare('SELECT encrypted_key FROM api_keys WHERE id = ?')
+        .get('sec-key-preserve') as { encrypted_key: string } | undefined;
+      expect(row?.encrypted_key).toBeTruthy();
+      expect(row?.encrypted_key).not.toBe('sk-original-secret');
+
+      const { decryptApiKey } = await import('../../src/core/crypto.js');
+      expect(decryptApiKey(row?.encrypted_key ?? '')).toBe('sk-original-secret');
+    });
+  });
+
+  describe('Provider URL validation', () => {
+    it('rejects remote provider with private baseUrl on create', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers',
+        headers: testAuthHeaders(),
+        payload: {
+          id: 'sec-provider-ssrf',
+          type: 'openai',
+          name: 'SSRF Blocked',
+          baseUrl: 'http://192.168.1.50/v1',
+          enabled: true,
+          apiKeys: [{ id: 'k1', name: 'default', key: 'sk-test' }],
+        },
+      });
+      expect(response.statusCode).toBe(400);
+      const body = response.json() as { error?: string };
+      expect(body.error).toMatch(/SSRF|私有/);
+    });
+
+    it('rejects ollama provider with non-localhost baseUrl on create', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/providers',
+        headers: testAuthHeaders(),
+        payload: {
+          id: 'sec-provider-ollama-remote',
+          type: 'ollama',
+          name: 'Ollama Remote',
+          baseUrl: 'http://192.168.1.10:11434',
+          enabled: true,
+        },
+      });
+      expect(response.statusCode).toBe(400);
+      const body = response.json() as { error?: string };
+      expect(body.error).toMatch(/localhost|127\.0\.0\.1|本地/);
+    });
+  });
+
+  describe('Keyless provider connection test SSRF', () => {
+    it('blocks keyless provider test against non-localhost URL', async () => {
+      const providerId = saveProvider({
+        id: 'sec-ollama-bad-url',
+        type: 'ollama',
+        name: 'Bad Ollama',
+        baseUrl: 'http://192.168.1.20:11434',
+        enabled: true,
+        isDefault: true,
+      });
+      saveModel(providerId, { id: 'sec-model-llama3', name: 'llama3', modelId: 'llama3', enabled: true });
+
+      const { aiConfig } = await import('../../src/api/routes/ai.js');
+      aiConfig.config.current_provider = 'ollama';
+      aiConfig.config.current_model = 'llama3';
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/config/ai/test',
+        headers: testAuthHeaders(),
+      });
+      expect(response.statusCode).toBe(200);
+      const body = response.json() as { success: boolean; error?: string };
+      expect(body.success).toBe(false);
+      expect(body.error).toMatch(/localhost|127\.0\.0\.1|本地/);
+    });
+  });
+
+  describe('MCP hardening', () => {
+    it('does not expose cli_run in MCP catalog', () => {
+      const catalog = getMcpToolsCatalog();
+      expect(catalog.tools).not.toContain('cli_run');
+      expect(catalog.categories.cli).not.toContain('cli_run');
+    });
+
+    it('rejects cli_run execution via executeMcpTool', async () => {
+      const result = await executeMcpTool('cli_run', { args: ['status'] });
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toContain('未知工具');
+    });
+  });
+
+  describe('File preview response headers', () => {
+    it('serves text preview inline with sandbox CSP', async () => {
+      const content = Buffer.from('inline text').toString('base64');
+      const file = saveFile('inline.txt', content, 'text/plain');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/files/${file.id}/preview`,
+        headers: testAuthHeaders(),
+      });
+      expect(response.statusCode).toBe(200);
+      expect(String(response.headers['content-disposition'] ?? '')).toContain('inline');
+      expect(response.headers['content-security-policy']).toBeDefined();
+    });
+
+    it('forces attachment for non-image binary preview', async () => {
+      const content = Buffer.from('%PDF-1.4 fake').toString('base64');
+      const file = saveFile('doc.pdf', content, 'application/pdf');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/files/${file.id}/preview`,
+        headers: testAuthHeaders(),
+      });
+      expect(response.statusCode).toBe(200);
+      expect(String(response.headers['content-disposition'] ?? '')).toContain('attachment');
+    });
+  });
+});

--- a/backend/tests/integration/server-auth.test.ts
+++ b/backend/tests/integration/server-auth.test.ts
@@ -85,4 +85,22 @@ describe('Server Auth Hook', () => {
 
     expect(response.statusCode).toBe(200);
   });
+
+  it('should reject GET /api/providers and /api/export without token', async () => {
+    for (const url of ['/api/providers', '/api/export']) {
+      const response = await (app as { inject: (opts: unknown) => Promise<{ statusCode: number }> }).inject({
+        method: 'GET',
+        url,
+      });
+      expect(response.statusCode).toBe(401);
+    }
+  });
+
+  it('should reject GET /api/mcp/cards without token', async () => {
+    const response = await (app as { inject: (opts: unknown) => Promise<{ statusCode: number }> }).inject({
+      method: 'GET',
+      url: '/api/mcp/cards',
+    });
+    expect(response.statusCode).toBe(401);
+  });
 });

--- a/backend/tests/integration/server-auth.test.ts
+++ b/backend/tests/integration/server-auth.test.ts
@@ -37,13 +37,22 @@ describe('Server Auth Hook', () => {
     delete process.env.PAPYRUS_AUTH_TOKEN;
   });
 
-  it('should allow GET without auth token', async () => {
+  it('should allow /api/health without auth token', async () => {
     const response = await (app as { inject: (opts: unknown) => Promise<{ statusCode: number }> }).inject({
       method: 'GET',
       url: '/api/health',
     });
 
     expect(response.statusCode).toBe(200);
+  });
+
+  it('should reject sensitive GET without auth token', async () => {
+    const response = await (app as { inject: (opts: unknown) => Promise<{ statusCode: number }> }).inject({
+      method: 'GET',
+      url: '/api/notes',
+    });
+
+    expect(response.statusCode).toBe(401);
   });
 
   it('should reject mutating request without auth token', async () => {
@@ -54,6 +63,16 @@ describe('Server Auth Hook', () => {
     });
 
     expect(response.statusCode).toBe(401);
+  });
+
+  it('should allow authenticated GET requests', async () => {
+    const response = await (app as { inject: (opts: unknown) => Promise<{ statusCode: number; json: () => Promise<unknown> }> }).inject({
+      method: 'GET',
+      url: '/api/notes',
+      headers: { 'x-papyrus-token': authToken },
+    });
+
+    expect(response.statusCode).toBe(200);
   });
 
   it('should allow mutating request with valid auth token', async () => {

--- a/backend/tests/integration/tools.test.ts
+++ b/backend/tests/integration/tools.test.ts
@@ -5,6 +5,7 @@ import { app, initApp, logger } from '../../src/api/server.js';
 import { closeDb, resetDb } from '../../src/db/database.js';
 import { PapyrusTools, CardTools } from '../../src/ai/tools.js';
 import { getToolManager, resetToolManager } from '../../src/ai/tool-manager.js';
+import { patchAppInjectWithAuth } from '../test-auth.js';
 
 describe('AI Tools Integration Tests', () => {
   const testDir = path.join(os.tmpdir(), `papyrus-tools-test-${Date.now()}`);
@@ -13,6 +14,7 @@ describe('AI Tools Integration Tests', () => {
     fs.mkdirSync(testDir, { recursive: true });
     process.env.PAPYRUS_DATA_DIR = testDir;
     await initApp();
+    patchAppInjectWithAuth(app);
     logger.setLogDir(path.join(testDir, 'logs'));
   });
 

--- a/backend/tests/jest-setup.ts
+++ b/backend/tests/jest-setup.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { TEST_AUTH_TOKEN } from './test-auth.js';
 
 const workerId = process.env.JEST_WORKER_ID ?? '0';
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `papyrus-jest-w${workerId}-`));
 process.env.PAPYRUS_DATA_DIR = tmpDir;
+process.env.PAPYRUS_AUTH_TOKEN = process.env.PAPYRUS_AUTH_TOKEN ?? TEST_AUTH_TOKEN;

--- a/backend/tests/security-exploit.test.ts
+++ b/backend/tests/security-exploit.test.ts
@@ -320,4 +320,42 @@ describe('Security Exploit Tests', () => {
     });
   });
 
+  describe('FND009 - API key leak via providers GET', () => {
+    it('should not return plaintext API keys from GET /api/providers', async () => {
+      const authToken = 'test-auth-token-' + 'x'.repeat(32);
+      process.env.PAPYRUS_AUTH_TOKEN = authToken;
+
+      if (!app) {
+        const serverModule = await import('../src/api/server.js');
+        await serverModule.initApp();
+        app = serverModule.app;
+        patchAppInjectWithAuth(app as { inject: (opts: Record<string, unknown>) => Promise<unknown> });
+      }
+
+      const { saveProvider, saveApiKey } = await import('../src/db/database.js');
+      const providerId = saveProvider({
+        id: 'fnd009-provider',
+        type: 'openai',
+        name: 'Leak Test',
+        baseUrl: 'https://api.openai.com/v1',
+        enabled: true,
+        isDefault: false,
+      });
+      saveApiKey(providerId, { id: 'fnd009-key', name: 'default', key: 'sk-must-not-leak-plaintext' });
+
+      const response = await (app as { inject: (opts: unknown) => Promise<{ statusCode: number; body: string }> }).inject({
+        method: 'GET',
+        url: '/api/providers',
+        headers: { 'x-papyrus-token': authToken },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).not.toContain('sk-must-not-leak-plaintext');
+      const body = JSON.parse(response.body) as {
+        providers: Array<{ apiKeys: Array<{ hasKey?: boolean; key: string }> }>;
+      };
+      expect(body.providers[0]?.apiKeys[0]?.hasKey).toBe(true);
+    });
+  });
+
 });

--- a/backend/tests/security-exploit.test.ts
+++ b/backend/tests/security-exploit.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { resetDb, closeDb, getDb } from '../src/db/database.js';
 import { isPrivateUrl } from '../src/ai/config.js';
 import { saveFile, deleteFileItem } from '../src/core/files.js';
+import { patchAppInjectWithAuth } from './test-auth.js';
 
 describe('Security Exploit Tests', () => {
   const testDir = path.join(os.tmpdir(), `papyrus-security-test-${Date.now()}`);
@@ -96,6 +97,7 @@ describe('Security Exploit Tests', () => {
       const serverModule = await import('../src/api/server.js');
       await serverModule.initApp();
       app = serverModule.app;
+      patchAppInjectWithAuth(app as { inject: (opts: Record<string, unknown>) => Promise<unknown> });
 
       const homeDir = path.resolve(os.homedir());
       const response = await (app as { inject: (opts: unknown) => Promise<{ statusCode: number; body: string }> }).inject({
@@ -118,6 +120,7 @@ describe('Security Exploit Tests', () => {
         const serverModule = await import('../src/api/server.js');
         await serverModule.initApp();
         app = serverModule.app;
+        patchAppInjectWithAuth(app as { inject: (opts: Record<string, unknown>) => Promise<unknown> });
       }
 
       const outsideDir = path.join(path.dirname(testDir), `papyrus-outside-log-target-${Date.now()}`);
@@ -177,6 +180,7 @@ describe('Security Exploit Tests', () => {
         const serverModule = await import('../src/api/server.js');
         await serverModule.initApp();
         app = serverModule.app;
+        patchAppInjectWithAuth(app as { inject: (opts: Record<string, unknown>) => Promise<unknown> });
       }
 
       const response = await (app as { inject: (opts: unknown) => Promise<{ statusCode: number; body: string }> }).inject({
@@ -207,6 +211,7 @@ describe('Security Exploit Tests', () => {
         const serverModule = await import('../src/api/server.js');
         await serverModule.initApp();
         app = serverModule.app;
+        patchAppInjectWithAuth(app as { inject: (opts: Record<string, unknown>) => Promise<unknown> });
       }
 
       const outsideDir = path.join(testDir, 'outside');
@@ -240,6 +245,7 @@ describe('Security Exploit Tests', () => {
         const serverModule = await import('../src/api/server.js');
         await serverModule.initApp();
         app = serverModule.app;
+        patchAppInjectWithAuth(app as { inject: (opts: Record<string, unknown>) => Promise<unknown> });
       }
 
       const file = saveFile('large-preview.txt', Buffer.alloc(11 * 1024 * 1024).toString('base64'));
@@ -261,6 +267,7 @@ describe('Security Exploit Tests', () => {
         const serverModule = await import('../src/api/server.js');
         await serverModule.initApp();
         app = serverModule.app;
+        patchAppInjectWithAuth(app as { inject: (opts: Record<string, unknown>) => Promise<unknown> });
       }
 
       const originalFetch = global.fetch;
@@ -312,4 +319,5 @@ describe('Security Exploit Tests', () => {
       expect(body.error).toMatch(/路径不存在|无法访问/);
     });
   });
+
 });

--- a/backend/tests/test-auth.ts
+++ b/backend/tests/test-auth.ts
@@ -1,0 +1,30 @@
+export const TEST_AUTH_TOKEN = 'test-jest-auth-token-32-chars-minimum';
+
+export function testAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    'x-papyrus-token': process.env.PAPYRUS_AUTH_TOKEN ?? TEST_AUTH_TOKEN,
+    ...extra,
+  };
+}
+
+type InjectableApp = {
+  inject: (opts: Record<string, unknown>) => Promise<unknown>;
+};
+
+// 为集成测试自动注入认证头，避免逐个修改数百处 app.inject 调用。
+// 原因：安全加固后所有 /api 路由都需要 token，测试夹具必须统一携带。
+// 未在 server 内对 test 环境放行：那会削弱认证回归测试的价值。
+export function patchAppInjectWithAuth(app: InjectableApp): void {
+  const token = process.env.PAPYRUS_AUTH_TOKEN ?? TEST_AUTH_TOKEN;
+  const originalInject = app.inject.bind(app);
+  app.inject = ((opts: Record<string, unknown>) => {
+    const existingHeaders = (opts.headers as Record<string, string> | undefined) ?? {};
+    return originalInject({
+      ...opts,
+      headers: {
+        'x-papyrus-token': token,
+        ...existingHeaders,
+      },
+    });
+  }) as typeof app.inject;
+}

--- a/backend/tests/unit/ai-tools-files.test.ts
+++ b/backend/tests/unit/ai-tools-files.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
 import { FILE_TOOLS } from '../../src/ai/tools/files.js';
 import { saveFile, createFolder } from '../../src/core/files.js';
+import { insertFile } from '../../src/db/database.js';
 import type { ToolRunContext } from '../../src/ai/tools/types.js';
 
 describe('ai-tools-files', () => {
@@ -80,6 +81,34 @@ describe('ai-tools-files', () => {
       const result = getTool('read_file').runner({ file_id: file.id }, ctx);
       expect(result.success).toBe(true);
       expect(result.content).toBe('hello world');
+    });
+
+    it('rejects file records pointing outside vault storage', () => {
+      const outsidePath = path.join(os.tmpdir(), `papyrus-outside-read-${Date.now()}.txt`);
+      fs.writeFileSync(outsidePath, 'outside vault', 'utf8');
+      const now = Date.now() / 1000;
+      insertFile({
+        id: 'outside-file-record',
+        name: 'outside.txt',
+        type: 'file',
+        size: 13,
+        mime_type: 'text/plain',
+        parent_id: null,
+        file_storage_path: outsidePath,
+        is_folder: 0,
+        created_at: now,
+        updated_at: now,
+      });
+
+      const result = getTool('read_file').runner({ file_id: 'outside-file-record' }, ctx);
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/存储目录|vault|允许/);
+
+      try {
+        fs.rmSync(outsidePath, { force: true });
+      } catch {
+        // ignore cleanup errors
+      }
     });
   });
 });

--- a/backend/tests/unit/auth.test.ts
+++ b/backend/tests/unit/auth.test.ts
@@ -9,6 +9,13 @@ describe('auth', () => {
   let getAuthToken: () => string | null;
   let isAuthEnabled: () => boolean;
   let validateRequestToken: (token?: string) => boolean;
+  let isPublicApiPath: (url: string) => boolean;
+  let extractRequestToken: (
+    headerToken: string | string[] | undefined,
+    queryAccessToken?: string,
+  ) => string | undefined;
+  let allowsQueryTokenAuth: (url: string) => boolean;
+  let ensureAuthToken: () => string;
 
   beforeAll(async () => {
     fs.mkdirSync(testDir, { recursive: true });
@@ -21,6 +28,10 @@ describe('auth', () => {
     getAuthToken = authModule.getAuthToken;
     isAuthEnabled = authModule.isAuthEnabled;
     validateRequestToken = authModule.validateRequestToken;
+    isPublicApiPath = authModule.isPublicApiPath;
+    extractRequestToken = authModule.extractRequestToken;
+    allowsQueryTokenAuth = authModule.allowsQueryTokenAuth;
+    ensureAuthToken = authModule.ensureAuthToken;
   });
 
   afterAll(() => {
@@ -76,6 +87,34 @@ describe('auth', () => {
     const token = getOrCreateAuthToken();
     expect(token).not.toBe('short');
     expect(token.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('should only treat /api/health as public path', () => {
+    expect(isPublicApiPath('/api/health')).toBe(true);
+    expect(isPublicApiPath('/api/health?verbose=1')).toBe(true);
+    expect(isPublicApiPath('/api/providers')).toBe(false);
+    expect(isPublicApiPath('/api/export')).toBe(false);
+  });
+
+  it('should extract token from header or query', () => {
+    expect(extractRequestToken('header-token')).toBe('header-token');
+    expect(extractRequestToken(['array-token'])).toBe('array-token');
+    expect(extractRequestToken(undefined, 'query-token')).toBe('query-token');
+    expect(extractRequestToken(undefined)).toBeUndefined();
+  });
+
+  it('should allow query token only on file media routes', () => {
+    expect(allowsQueryTokenAuth('/api/files/abc/preview')).toBe(true);
+    expect(allowsQueryTokenAuth('/api/files/abc/thumbnail')).toBe(true);
+    expect(allowsQueryTokenAuth('/api/files/abc/download')).toBe(true);
+    expect(allowsQueryTokenAuth('/api/notes')).toBe(false);
+    expect(allowsQueryTokenAuth('/api/files/abc')).toBe(false);
+  });
+
+  it('should ensure auth token exists on startup helper', () => {
+    const token = ensureAuthToken();
+    expect(token.length).toBeGreaterThanOrEqual(32);
+    expect(getAuthToken()).toBe(token);
   });
 
   describe('edge cases', () => {

--- a/backend/tests/unit/cli-manager.test.ts
+++ b/backend/tests/unit/cli-manager.test.ts
@@ -121,7 +121,7 @@ describe('CliManager', () => {
     });
 
     const catalog = getMcpToolsCatalog();
-    expect(catalog.categories.cli).toEqual(['cli_status', 'cli_install', 'cli_run']);
+    expect(catalog.categories.cli).toEqual(['cli_status', 'cli_install']);
 
     const status = await executeMcpTool('cli_status', {}, undefined, manager);
     expect(status.success).toBe(true);

--- a/backend/tests/unit/cli-manager.test.ts
+++ b/backend/tests/unit/cli-manager.test.ts
@@ -122,6 +122,11 @@ describe('CliManager', () => {
 
     const catalog = getMcpToolsCatalog();
     expect(catalog.categories.cli).toEqual(['cli_status', 'cli_install']);
+    expect(catalog.tools).not.toContain('cli_run');
+
+    const blocked = await executeMcpTool('cli_run', { args: ['status'] }, undefined, manager);
+    expect(blocked.success).toBe(false);
+    expect(String(blocked.error)).toContain('未知工具');
 
     const status = await executeMcpTool('cli_status', {}, undefined, manager);
     expect(status.success).toBe(true);

--- a/backend/tests/unit/database.test.ts
+++ b/backend/tests/unit/database.test.ts
@@ -27,6 +27,7 @@ describe('Database', () => {
   let getNoteCount: typeof import('../../src/db/database.js').getNoteCount;
   let getAllFolders: typeof import('../../src/db/database.js').getAllFolders;
   let loadAllProviders: typeof import('../../src/db/database.js').loadAllProviders;
+  let loadAllProvidersForClient: typeof import('../../src/db/database.js').loadAllProvidersForClient;
   let saveProvider: typeof import('../../src/db/database.js').saveProvider;
   let deleteProvider: typeof import('../../src/db/database.js').deleteProvider;
   let setDefaultProvider: typeof import('../../src/db/database.js').setDefaultProvider;
@@ -73,6 +74,7 @@ describe('Database', () => {
     getNoteCount = db.getNoteCount as typeof getNoteCount;
     getAllFolders = db.getAllFolders as typeof getAllFolders;
     loadAllProviders = db.loadAllProviders as typeof loadAllProviders;
+    loadAllProvidersForClient = db.loadAllProvidersForClient as typeof loadAllProvidersForClient;
     saveProvider = db.saveProvider as typeof saveProvider;
     deleteProvider = db.deleteProvider as typeof deleteProvider;
     setDefaultProvider = db.setDefaultProvider as typeof setDefaultProvider;
@@ -334,6 +336,21 @@ describe('Database', () => {
       const found = providers.find((p) => p.id === id);
       // @ts-expect-error - tested above
       expect(found.enabled).toBe(true);
+    });
+
+    it('should mask API keys in loadAllProvidersForClient', () => {
+      const id = saveProvider({ type: 'openai', name: 'ClientMask', baseUrl: 'https://api.example.com', enabled: true });
+      saveApiKey(id, { id: 'mask-key', name: 'default', key: 'sk-client-secret-value' });
+
+      const internal = loadAllProviders();
+      const client = loadAllProvidersForClient();
+      const internalProvider = internal.find((p) => p.id === id);
+      const clientProvider = client.find((p) => p.id === id);
+
+      expect(internalProvider?.apiKeys[0]?.key).toBe('sk-client-secret-value');
+      expect(clientProvider?.apiKeys[0]?.hasKey).toBe(true);
+      expect(clientProvider?.apiKeys[0]?.key).not.toContain('sk-client-secret');
+      expect(clientProvider?.apiKeys[0]?.key).toMatch(/^\*+$/);
     });
   });
 

--- a/backend/tests/unit/mcp-server.test.ts
+++ b/backend/tests/unit/mcp-server.test.ts
@@ -57,16 +57,27 @@ describe('MCPServer', () => {
     expect((res.body as Record<string, unknown>).status).toBe('ok');
   });
 
-  it('should list tools', async () => {
+  it('should list tools with valid auth', async () => {
+    server = new MCPServer({ port: 0, authToken: 'test-token' });
+    await server.start();
+    const port = server.getActualPort();
+
+    const res = await makeRequest(port, '/tools', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as Record<string, unknown>;
+    expect(Array.isArray(body.tools)).toBe(true);
+    expect(Array.isArray((body.categories as Record<string, unknown>).cards)).toBe(true);
+  });
+
+  it('should reject unauthenticated tools listing', async () => {
     server = new MCPServer({ port: 0, authToken: 'test-token' });
     await server.start();
     const port = server.getActualPort();
 
     const res = await makeRequest(port, '/tools');
-    expect(res.status).toBe(200);
-    const body = res.body as Record<string, unknown>;
-    expect(Array.isArray(body.tools)).toBe(true);
-    expect(Array.isArray((body.categories as Record<string, unknown>).cards)).toBe(true);
+    expect(res.status).toBe(401);
   });
 
   it('should reject unauthorized call', async () => {

--- a/backend/tests/unit/provider-security.test.ts
+++ b/backend/tests/unit/provider-security.test.ts
@@ -1,0 +1,35 @@
+import {
+  validateProviderBaseUrl,
+  isMaskedApiKeySubmission,
+  maskApiKeyForDisplay,
+} from '../../src/utils/provider-security.js';
+
+describe('provider-security', () => {
+  it('allows localhost for ollama', () => {
+    expect(validateProviderBaseUrl('http://localhost:11434', 'ollama')).toBeNull();
+    expect(validateProviderBaseUrl('http://127.0.0.1:11434', 'ollama')).toBeNull();
+  });
+
+  it('blocks private URLs for remote providers', () => {
+    expect(validateProviderBaseUrl('http://192.168.1.1/v1', 'openai')).toMatch(/SSRF/);
+    expect(validateProviderBaseUrl('http://169.254.169.254/', 'deepseek')).toMatch(/SSRF/);
+  });
+
+  it('blocks non-local hosts for keyless providers', () => {
+    expect(validateProviderBaseUrl('http://192.168.1.1:11434', 'ollama')).toMatch(/localhost/);
+  });
+
+  it('detects masked API key submissions', () => {
+    expect(isMaskedApiKeySubmission('')).toBe(true);
+    expect(isMaskedApiKeySubmission('********abcd')).toBe(true);
+    expect(isMaskedApiKeySubmission('sk-live-real-key-value')).toBe(false);
+  });
+
+  it('masks stored keys for client responses', () => {
+    expect(maskApiKeyForDisplay(false)).toEqual({ key: '', hasKey: false });
+    expect(maskApiKeyForDisplay(true, 'sk-abcdefghijklmnop')).toEqual({
+      key: '***************mnop',
+      hasKey: true,
+    });
+  });
+});

--- a/backend/tests/unit/provider-security.test.ts
+++ b/backend/tests/unit/provider-security.test.ts
@@ -31,5 +31,16 @@ describe('provider-security', () => {
       key: '***************mnop',
       hasKey: true,
     });
+    expect(maskApiKeyForDisplay(true)).toEqual({ key: '********', hasKey: true });
+  });
+
+  it('rejects invalid URL schemes for providers', () => {
+    expect(validateProviderBaseUrl('file:///etc/passwd', 'openai')).toMatch(/http|https/);
+    expect(validateProviderBaseUrl('not-a-url', 'openai')).toMatch(/无效/);
+  });
+
+  it('allows empty baseUrl', () => {
+    expect(validateProviderBaseUrl('', 'openai')).toBeNull();
+    expect(validateProviderBaseUrl('   ', 'openai')).toBeNull();
   });
 });

--- a/electron/main.js
+++ b/electron/main.js
@@ -307,7 +307,7 @@ function createWindow() {
       responseHeaders: {
         ...details.responseHeaders,
         'Content-Security-Policy': [
-          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://127.0.0.1:* http://localhost:* https:; img-src 'self' file: data: http://127.0.0.1:* http://localhost:* https: blob:; media-src 'self' http://127.0.0.1:* http://localhost:* blob:; font-src 'self' data:; frame-src 'self';",
+          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://127.0.0.1:* http://localhost:*; img-src 'self' file: data: http://127.0.0.1:* http://localhost:* blob:; media-src 'self' http://127.0.0.1:* http://localhost:* blob:; font-src 'self' data:; frame-src 'self';",
         ],
       },
     });
@@ -506,7 +506,39 @@ function setupIPC() {
   // Check if development mode
   ipcMain.handle('app:isDev', () => isDevMode);
 
-  // Get backend auth token (for API requests from renderer)
+  // Proxy API requests through main process so the renderer never needs the raw token.
+  ipcMain.handle('api:fetch', async (_event, payload) => {
+    const apiPath = typeof payload?.path === 'string' ? payload.path : '';
+    const method = typeof payload?.method === 'string' ? payload.method : 'GET';
+    const body = payload?.body;
+    const extraHeaders = payload?.headers && typeof payload.headers === 'object' ? payload.headers : {};
+    const url = `http://${CONFIG.backendHost}:${CONFIG.backendPort}/api${apiPath}`;
+    const response = await fetch(url, {
+      method,
+      headers: {
+        ...extraHeaders,
+        'X-Papyrus-Token': PAPYRUS_AUTH_TOKEN,
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const text = await response.text();
+    return {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      body: text,
+    };
+  });
+
+  // Media URLs for <img> tags that cannot attach auth headers.
+  ipcMain.handle('api:getMediaUrl', (_event, fileId, action) => {
+    const safeId = typeof fileId === 'string' ? fileId : '';
+    const safeAction = action === 'download' ? 'download' : action === 'preview' ? 'preview' : 'thumbnail';
+    return `http://${CONFIG.backendHost}:${CONFIG.backendPort}/api/files/${safeId}/${safeAction}?access_token=${encodeURIComponent(PAPYRUS_AUTH_TOKEN)}`;
+  });
+
+  // Legacy token accessor — kept for streaming endpoints until fully proxied.
   ipcMain.handle('app:getAuthToken', () => PAPYRUS_AUTH_TOKEN);
 
   // Quit the application (sets isQuitting so window.close() actually quits)

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -14,9 +14,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getVersion: () => ipcRenderer.invoke('app:getVersion'),
   getPlatform: () => ipcRenderer.invoke('app:getPlatform'),
   isDev: () => ipcRenderer.invoke('app:isDev'),
-  // SECURITY: getAuthToken is exposed to renderer. If XSS occurs in renderer,
-  // an attacker could steal this token. Consider proxying API calls through
-  // ipcRenderer instead of exposing the raw token.
+  apiFetch: (payload) => ipcRenderer.invoke('api:fetch', payload),
+  getMediaUrl: (fileId, action) => ipcRenderer.invoke('api:getMediaUrl', fileId, action),
+  // Legacy: streaming chat still reads token for SSE headers.
   getAuthToken: () => ipcRenderer.invoke('app:getAuthToken'),
 
   // Shell operations

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -321,9 +321,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -341,9 +338,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -361,9 +355,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -381,9 +372,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -401,9 +389,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -421,9 +406,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1630,9 +1612,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1654,9 +1633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1678,9 +1654,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1702,9 +1675,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,7 @@ import ExtensionsPage from './ExtensionsPage/ExtensionsPage';
 import FilesPage from './FilesPage/FilesPage';
 import SettingsPage from './SettingsPage/SettingsPage';
 import SectionNavigation from './components/SectionNavigation';
-import { api, type ChatPanelSide, type SearchResult } from './api';
+import { api, getAuthToken, type ChatPanelSide, type SearchResult } from './api';
 import { addRecentItem } from './utils/recentFiles';
 
 const PAGE_ORDER = ['start', 'scroll', 'notes', 'charts', 'files', 'extensions', 'settings'];
@@ -80,6 +80,7 @@ const App = () => {
   const transitionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    void getAuthToken();
     let cancelled = false;
     api.getSidebarSettings()
       .then((res) => {

--- a/frontend/src/SettingsPage/views/ChatView/components/ModelsSection.tsx
+++ b/frontend/src/SettingsPage/views/ChatView/components/ModelsSection.tsx
@@ -54,7 +54,7 @@ const ModelsSection = ({ providers, currentModelId, saveDefaultModel, deleteMode
                       {renderCapabilityIcons(model.capabilities, t)}
                     </div>
                     <Paragraph type="secondary" style={{ fontSize: 12, margin: '4px 0 0 0' }}>
-                      Key: {apiKey?.name || 'default'} {apiKey?.key ? `(${t('chatView.configured')})` : `(${t('chatView.notConfigured')})`}
+                      Key: {apiKey?.name || 'default'} {(apiKey?.hasKey || apiKey?.key) ? `(${t('chatView.configured')})` : `(${t('chatView.notConfigured')})`}
                     </Paragraph>
                   </div>
                   <Space size={4}>

--- a/frontend/src/SettingsPage/views/ChatView/components/ProvidersSection.tsx
+++ b/frontend/src/SettingsPage/views/ChatView/components/ProvidersSection.tsx
@@ -86,7 +86,7 @@ const ProvidersSection = ({ providers, loadProviders, deleteProvider, setDefault
           Message.success(t('chatView.supplierConfigSaved'));
           loadProviders();
           notifyAIConfigChanged();
-          const firstKey = provider.apiKeys.find(k => k.key.trim() !== '');
+          const firstKey = provider.apiKeys.find(k => k.key.trim() !== '' && !/^\*+/.test(k.key.trim()));
           if (firstKey) {
             syncKeyToAIConfig(provider.type, firstKey.key);
           }
@@ -179,7 +179,7 @@ const ProvidersSection = ({ providers, loadProviders, deleteProvider, setDefault
                           <Input.Password 
                             value={apiKey.key}
                             onChange={(v) => updateApiKey(provider.id, apiKey.id, { key: v })}
-                            placeholder={`Enter ${t('chatView.apiKey')}`}
+                            placeholder={apiKey.hasKey && !apiKey.key ? t('chatView.configured') : `Enter ${t('chatView.apiKey')}`}
                             style={{ flex: 1, border: '1px solid var(--color-border-2)', borderRadius: '6px', background: 'var(--color-bg-2)' }}
                           />
                           {index === 0 ? (

--- a/frontend/src/SettingsPage/views/ChatView/types/index.ts
+++ b/frontend/src/SettingsPage/views/ChatView/types/index.ts
@@ -4,6 +4,7 @@ export interface ApiKeyItem {
   id: string;
   name: string;
   key: string;
+  hasKey?: boolean;
 }
 
 export interface Model {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,11 +4,19 @@ export const BASE = window.location.protocol === 'file:'
   : '/api';
 
 export function getFileUrl(fileId: string, action: 'preview' | 'download'): string {
-  return `${BASE}/files/${fileId}/${action}`;
+  const base = `${BASE}/files/${fileId}/${action}`;
+  if (cachedToken) {
+    return `${base}?access_token=${encodeURIComponent(cachedToken)}`;
+  }
+  return base;
 }
 
 export function getThumbnailUrl(fileId: string): string {
-  return `${BASE}/files/${fileId}/thumbnail`;
+  const base = `${BASE}/files/${fileId}/thumbnail`;
+  if (cachedToken) {
+    return `${base}?access_token=${encodeURIComponent(cachedToken)}`;
+  }
+  return base;
 }
 
 export let cachedToken: string | null | undefined;
@@ -114,6 +122,45 @@ async function parseErrorBody(res: Response): Promise<unknown> {
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   try {
+    const electronAPI = (window as unknown as {
+      electronAPI?: {
+        apiFetch?: (payload: {
+          path: string;
+          method?: string;
+          body?: unknown;
+          headers?: Record<string, string>;
+        }) => Promise<{ ok: boolean; status: number; statusText: string; body: string }>;
+        getAuthToken?: () => Promise<string | null>;
+      };
+    }).electronAPI;
+
+    if (electronAPI?.apiFetch) {
+      const hasBody = init?.body !== undefined;
+      let parsedBody: unknown;
+      if (hasBody && typeof init.body === 'string') {
+        parsedBody = JSON.parse(init.body);
+      }
+      const proxied = await electronAPI.apiFetch({
+        path,
+        method: init?.method ?? 'GET',
+        body: parsedBody,
+        headers: (init?.headers as Record<string, string> | undefined) ?? {},
+      });
+      if (!proxied.ok) {
+        let body: unknown;
+        try {
+          body = JSON.parse(proxied.body);
+        } catch {
+          body = { error: proxied.body || proxied.statusText };
+        }
+        throw new Error(buildErrorMessage(body, proxied.statusText));
+      }
+      if (!proxied.body.trim()) {
+        return {} as T;
+      }
+      return JSON.parse(proxied.body) as T;
+    }
+
     const token = await getAuthToken();
     const hasBody = init?.body !== undefined;
     const res = await fetch(`${BASE}${path}`, {
@@ -500,7 +547,7 @@ export type ProviderItem = {
   baseUrl: string;
   enabled: boolean;
   isDefault: boolean;
-  apiKeys: { id: string; name: string; key: string }[];
+  apiKeys: { id: string; name: string; key: string; hasKey?: boolean }[];
   models: { id: string; name: string; modelId: string; port: string; capabilities: string[]; apiKeyId?: string; enabled: boolean }[];
 };
 

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -14,6 +14,17 @@ export interface ElectronAPI {
   
   /** Check if running in development mode */
   isDev(): Promise<boolean>;
+
+  /** Proxy authenticated API requests through the main process */
+  apiFetch(payload: {
+    path: string;
+    method?: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+  }): Promise<{ ok: boolean; status: number; statusText: string; body: string }>;
+
+  /** Build an authenticated media URL for img/video tags */
+  getMediaUrl(fileId: string, action: 'preview' | 'download' | 'thumbnail'): Promise<string>;
   
   /** Open an external URL in the default browser */
   openExternal(url: string): Promise<void>;
@@ -39,7 +50,7 @@ export interface ElectronAPI {
   /** Quit the entire application */
   quitApp(): Promise<void>;
 
-  /** Get the backend auth token */
+  /** Get the backend auth token (legacy — prefer apiFetch) */
   getAuthToken(): Promise<string | null>;
 
   /** Check if window is maximized */

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,12 +1,32 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { readFileSync, existsSync } from 'fs'
+import { resolve, join } from 'path'
+import os from 'os'
 
 const rootPkg = JSON.parse(
   readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8')
 )
 const appVersion = rootPkg.version ?? 'unknown'
+
+function readDevAuthToken(): string | null {
+  if (process.env.PAPYRUS_AUTH_TOKEN) {
+    return process.env.PAPYRUS_AUTH_TOKEN
+  }
+  const dataDir = process.env.PAPYRUS_DATA_DIR
+    ? resolve(process.env.PAPYRUS_DATA_DIR)
+    : join(os.homedir(), 'PapyrusData')
+  const tokenFile = join(dataDir, '.api_token')
+  try {
+    if (existsSync(tokenFile)) {
+      const token = readFileSync(tokenFile, 'utf8').trim()
+      return token.length >= 32 ? token : null
+    }
+  } catch {
+    // ignore token read errors in dev proxy
+  }
+  return null
+}
 
 // TS + React 19 + Arco scaffold
 export default defineConfig({
@@ -27,6 +47,14 @@ export default defineConfig({
      '/api': {
        target: 'http://127.0.0.1:8000',
        changeOrigin: true,
+       configure: (proxy) => {
+         proxy.on('proxyReq', (proxyReq) => {
+           const token = readDevAuthToken()
+           if (token) {
+             proxyReq.setHeader('x-papyrus-token', token)
+           }
+         })
+       },
      },
    },
  },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the critical and high-severity findings from the security audit.

### Authentication
- All `/api/*` routes now require `X-Papyrus-Token` (except `/api/health`)
- Server always calls `ensureAuthToken()` on startup so standalone dev backends are protected
- File preview/thumbnail/download support `access_token` query param for `<img>` tags
- Vite dev proxy auto-injects token from `PAPYRUS_AUTH_TOKEN` or `.api_token` file

### API Key Protection
- `GET /api/providers` returns masked keys with `hasKey` flag — never plaintext
- Provider updates skip masked/empty key submissions to avoid overwriting stored secrets
- `loadAllProvidersForClient()` avoids decrypting keys for list responses

### SSRF
- New `validateProviderBaseUrl()` enforces localhost-only for keyless providers (Ollama, etc.)
- Fixed keyless provider connection test bypass in `ai-config.ts`
- Ollama chat/completion paths use the same validation
- Provider `baseUrl` validated on create/update; removed Zod `.passthrough()`

### MCP & CLI
- Removed `cli_run` from MCP tool catalog (still available via `/api/cli/run` with auth)
- Standalone MCP `/tools` endpoint now requires Bearer auth
- MCP server shares backend auth token

### Path & File Security
- AI `read_file` tool checks `isSafeFileStoragePath`
- Obsidian import uses `isPathInsideDirectory` instead of `startsWith`
- Non-image file previews use `Content-Disposition: attachment` + CSP sandbox

### Electron
- Added `api:fetch` IPC proxy so renderer avoids direct token usage for REST calls
- Added `api:getMediaUrl` for authenticated media URLs
- Tightened CSP (removed `unsafe-inline` scripts and broad `https:` connect-src)

### Tests (696 passing)
- **New** `integration/security-hardening.test.ts` — end-to-end regression for auth boundaries, key masking/preservation, SSRF on provider save & keyless test, MCP `cli_run` removal, file preview headers, `access_token` query auth
- **Extended** `server-auth.test.ts` — providers/export/mcp GET rejection
- **Extended** `unit/auth.test.ts` — `isPublicApiPath`, `extractRequestToken`, `allowsQueryTokenAuth`, `ensureAuthToken`
- **Extended** `unit/provider-security.test.ts` — invalid URL schemes, empty baseUrl
- **Extended** `unit/database.test.ts` — `loadAllProvidersForClient` masking
- **Extended** `unit/ai-tools-files.test.ts` — outside-vault path rejection
- **Extended** `security-exploit.test.ts` — FND009 API key leak regression
- **Extended** `unit/cli-manager.test.ts` — `cli_run` blocked in catalog and execution

## Remaining follow-ups (not in this PR)
- SSRF redirect/DNS rebinding protection
- OS keychain integration for `.master_key`
- Full removal of `getAuthToken` from preload (streaming still uses it)
- `npm audit fix` for dependency vulnerabilities
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d08d952f-df19-4689-bfa1-f4c42d1a3a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d08d952f-df19-4689-bfa1-f4c42d1a3a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

