### PR TITLE
fix: address Codex review on PR #23 (token reuse & PDF preview)

### DIFF
--- a/backend/src/api/routes/files.ts
+++ b/backend/src/api/routes/files.ts
@@ -5,10 +5,12 @@ import { listFiles, createFolder, saveFile, deleteFileItem, getFileById, isSafeF
 
 const MAX_PREVIEW_SIZE = 10 * 1024 * 1024;
 const THUMBNAIL_SIZE = 128;
+const INLINE_PREVIEW_MIME_TYPES = new Set(['application/pdf']);
 const INLINE_PREVIEW_PREFIXES = ['image/', 'text/'];
 
 function shouldServeInline(mimeType: string | null | undefined): boolean {
   if (!mimeType) return false;
+  if (INLINE_PREVIEW_MIME_TYPES.has(mimeType)) return true;
   return INLINE_PREVIEW_PREFIXES.some((prefix) => mimeType.startsWith(prefix));
 }
 

--- a/backend/tests/integration/security-hardening.test.ts
+++ b/backend/tests/integration/security-hardening.test.ts
@@ -258,9 +258,22 @@ describe('Security Hardening Integration', () => {
       expect(response.headers['content-security-policy']).toBeDefined();
     });
 
-    it('forces attachment for non-image binary preview', async () => {
+    it('serves PDF preview inline with sandbox CSP', async () => {
       const content = Buffer.from('%PDF-1.4 fake').toString('base64');
       const file = saveFile('doc.pdf', content, 'application/pdf');
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/files/${file.id}/preview`,
+        headers: testAuthHeaders(),
+      });
+      expect(response.statusCode).toBe(200);
+      expect(String(response.headers['content-disposition'] ?? '')).toContain('inline');
+      expect(response.headers['content-security-policy']).toBeDefined();
+    });
+
+    it('forces attachment for non-previewable binary files', async () => {
+      const content = Buffer.from([0x50, 0x4b, 0x03, 0x04]).toString('base64');
+      const file = saveFile('archive.zip', content, 'application/zip');
       const response = await app.inject({
         method: 'GET',
         url: `/api/files/${file.id}/preview`,

--- a/electron/main.js
+++ b/electron/main.js
@@ -22,6 +22,51 @@ const { validateExternalUrl, validateOpenFolderPath } = require('./security-vali
 
 // Generate a per-session auth token for backend API protection
 const PAPYRUS_AUTH_TOKEN = crypto.randomBytes(32).toString('base64url');
+// Effective token used for IPC-proxied API calls; may differ when reusing an already-running backend.
+let effectiveAuthToken = PAPYRUS_AUTH_TOKEN;
+
+// Resolve backend data directory (matches backend/src/utils/paths.ts defaults).
+function getBackendDataDir() {
+  if (process.env.PAPYRUS_DATA_DIR) {
+    return path.resolve(process.env.PAPYRUS_DATA_DIR);
+  }
+  return path.join(os.homedir(), 'PapyrusData');
+}
+
+// Read the token the running backend actually expects (env or persisted .api_token).
+function readPersistedBackendToken(additionalDataDirs = []) {
+  const envToken = process.env.PAPYRUS_AUTH_TOKEN;
+  if (typeof envToken === 'string' && envToken.length >= 32) {
+    return envToken;
+  }
+  const candidateDirs = [getBackendDataDir(), ...additionalDataDirs];
+  for (const dir of candidateDirs) {
+    const tokenFile = path.join(dir, '.api_token');
+    try {
+      if (fs.existsSync(tokenFile)) {
+        const token = fs.readFileSync(tokenFile, 'utf8').trim();
+        if (token.length >= 32) {
+          return token;
+        }
+      }
+    } catch {
+      // ignore token read errors
+    }
+  }
+  return null;
+}
+
+// When dev scripts start the backend before Electron, reuse its token instead of the per-session one.
+function resolveAuthTokenForExistingBackend() {
+  const extraDirs = app.isReady() ? [app.getPath('userData')] : [];
+  const persisted = readPersistedBackendToken(extraDirs);
+  if (persisted) {
+    effectiveAuthToken = persisted;
+    log('Reusing existing backend auth token');
+    return;
+  }
+  log('Backend is running but no persisted auth token was found; API calls may return 401', 'error');
+}
 
 // In-memory log storage for diagnostics
 const startupLogs = [];
@@ -517,7 +562,7 @@ function setupIPC() {
       method,
       headers: {
         ...extraHeaders,
-        'X-Papyrus-Token': PAPYRUS_AUTH_TOKEN,
+        'X-Papyrus-Token': effectiveAuthToken,
         ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
       },
       body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -535,11 +580,11 @@ function setupIPC() {
   ipcMain.handle('api:getMediaUrl', (_event, fileId, action) => {
     const safeId = typeof fileId === 'string' ? fileId : '';
     const safeAction = action === 'download' ? 'download' : action === 'preview' ? 'preview' : 'thumbnail';
-    return `http://${CONFIG.backendHost}:${CONFIG.backendPort}/api/files/${safeId}/${safeAction}?access_token=${encodeURIComponent(PAPYRUS_AUTH_TOKEN)}`;
+    return `http://${CONFIG.backendHost}:${CONFIG.backendPort}/api/files/${safeId}/${safeAction}?access_token=${encodeURIComponent(effectiveAuthToken)}`;
   });
 
   // Legacy token accessor — kept for streaming endpoints until fully proxied.
-  ipcMain.handle('app:getAuthToken', () => PAPYRUS_AUTH_TOKEN);
+  ipcMain.handle('app:getAuthToken', () => effectiveAuthToken);
 
   // Quit the application (sets isQuitting so window.close() actually quits)
   ipcMain.handle('app:quit', () => {
@@ -678,6 +723,7 @@ app.whenReady().then(async () => {
     
     if (isBackendAlreadyRunning) {
       log('Backend is already running (likely started by dev script), skipping backend startup');
+      resolveAuthTokenForExistingBackend();
     } else {
       // Start backend only if not already running
       await startBackend();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to merged PR #23 addressing the two P2 findings from [Codex review](https://github.com/PapyrusOR/Papyrus_Desktop/pull/23#pullrequestreview-4657203002).

### 1. Reuse running backend token in `api:fetch` (electron:dev)

In `npm run electron:dev`, the dev script starts the backend before Electron. Electron then skips `startBackend()` when `/api/health` is already up. After the security hardening, the standalone backend creates/uses its own `.api_token`, but `api:fetch` always sent Electron's unrelated per-session `PAPYRUS_AUTH_TOKEN`, causing 401s for all renderer calls routed through the IPC proxy.

**Fix:** When joining an already-running backend, Electron now reads the persisted token from `PAPYRUS_AUTH_TOKEN` env or `.api_token` (matching backend/vite dev proxy logic) and uses it for `api:fetch`, `api:getMediaUrl`, and `app:getAuthToken`.

### 2. Keep PDF previews inline

`FilePreviewModal` renders PDFs in an iframe via `/preview`, but the hardening change marked all non-image/text files as `Content-Disposition: attachment`, breaking PDF preview.

**Fix:** Added `application/pdf` to the inline preview allowlist with sandbox CSP. Other binary types (e.g. zip) remain attachment-only.

### Tests

- Updated `security-hardening.test.ts`: PDF expects inline + CSP; zip expects attachment
- All 14 security-hardening integration tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37ed6551-a2a7-42f9-8eba-1c993670bf53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37ed6551-a2a7-42f9-8eba-1c993670bf53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

