### PR TITLE
docs: add centered README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# 📜 Papyrus Desktop
+<p align="center">
+  <img src="assets/icon.png" alt="Papyrus Desktop" width="180" />
+</p>
+
+<h1 align="center">Papyrus Desktop</h1>
+
+---
 
 **English** · [简体中文](README.zh-CN.md) · [日本語](README.ja.md)
 


### PR DESCRIPTION
## What changed

- Centered the existing Papyrus icon at the top of README.md.
- Added a centered Papyrus Desktop heading to match the supplied reference.

## Why

Creates a clearer branded entry point for repository visitors without changing the existing documentation content.

## Validation

- Ran `git diff --check`.
- Confirmed the diff is limited to README.md.