### PR TITLE
Fix path validation for symlinked macOS directories

### DIFF
--- a/backend/src/utils/security.ts
+++ b/backend/src/utils/security.ts
@@ -7,10 +7,32 @@ import path from 'node:path';
 // 未直接使用原始字符串：字符串路径无法识别链接跳转，容易产生目录绕过。
 export function resolveRealPathForSecurity(targetPath: string): string {
   const resolved = path.resolve(targetPath);
-  try {
-    return fs.realpathSync(resolved);
-  } catch {
-    return resolved;
+  const missingSegments: string[] = [];
+  let existingAncestor = resolved;
+
+  // realpath 只能直接解析已存在的目标。写入新日志目录或版本快照时，目标本身通常尚未创建，
+  // 但它的祖先仍可能经过 macOS 的 /var -> /private/var 等符号链接。
+  // 逐级查找最近的已存在祖先并解析它，再拼回缺失部分，既保持真实路径比较，
+  // 也不会把合法的新建子目录误判为越界。
+  while (true) {
+    try {
+      const realAncestor = fs.realpathSync(existingAncestor);
+      return path.join(realAncestor, ...missingSegments);
+    } catch (error) {
+      const errorCode = typeof error === 'object' && error !== null && 'code' in error
+        ? error.code
+        : undefined;
+      if (errorCode !== 'ENOENT') {
+        return resolved;
+      }
+
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) {
+        return resolved;
+      }
+      missingSegments.unshift(path.basename(existingAncestor));
+      existingAncestor = parent;
+    }
   }
 }
 

--- a/backend/tests/unit/security.test.ts
+++ b/backend/tests/unit/security.test.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { isPathInsideDirectory, resolveRealPathForSecurity } from '../../src/utils/security.js';
+
+describe('security path helpers', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  const itWithSymlinks = process.platform === 'win32' ? it.skip : it;
+
+  itWithSymlinks('resolves missing descendants through an existing symlink ancestor', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'papyrus-security-'));
+    tempDirs.push(tempDir);
+    const realRoot = path.join(tempDir, 'real-root');
+    const allowedRoot = path.join(realRoot, 'allowed');
+    const linkedRoot = path.join(tempDir, 'linked-root');
+    fs.mkdirSync(allowedRoot, { recursive: true });
+    fs.symlinkSync(realRoot, linkedRoot, 'dir');
+
+    const missingTarget = path.join(linkedRoot, 'allowed', 'new-directory', 'file.json');
+
+    expect(resolveRealPathForSecurity(missingTarget)).toBe(
+      path.join(fs.realpathSync(allowedRoot), 'new-directory', 'file.json'),
+    );
+    expect(isPathInsideDirectory(missingTarget, path.join(linkedRoot, 'allowed'))).toBe(true);
+  });
+
+  itWithSymlinks('rejects missing descendants below a symlink that escapes the allowed directory', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'papyrus-security-'));
+    tempDirs.push(tempDir);
+    const allowedRoot = path.join(tempDir, 'allowed');
+    const outsideRoot = path.join(tempDir, 'outside');
+    fs.mkdirSync(allowedRoot, { recursive: true });
+    fs.mkdirSync(outsideRoot, { recursive: true });
+    fs.symlinkSync(outsideRoot, path.join(allowedRoot, 'escape'), 'dir');
+
+    const escapedTarget = path.join(allowedRoot, 'escape', 'new-directory', 'file.json');
+
+    expect(isPathInsideDirectory(escapedTarget, allowedRoot)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve the nearest existing ancestor before validating a path whose final components do not exist yet
- preserve symlink escape protection while allowing legitimate new descendants
- add regression coverage for both allowed and escaping symlink paths

## Root cause

`realpathSync` was called only on the complete target path. When a new log directory or knowledge-version snapshot directory did not exist yet, resolution fell back to the lexical path. On macOS, an allowed directory could resolve through `/var` to `/private/var` while the missing target remained under `/var`, causing a false path-boundary rejection.

## Impact

New log directories and knowledge-version storage paths now pass validation when they are genuinely inside the configured data directory, including under symlinked macOS temporary paths. Paths that escape through a symlink remain rejected.

## Validation

- `npm test -- --runInBand` in `backend` — 50 suites and 784 tests passed
- `npm run typecheck` in `backend`
- `npm run typecheck` in `frontend`
- `git diff --check`
